### PR TITLE
Update C# model to PureQL spec 0.1.0-preview.0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,142 @@
+# Changelog
+
+All notable changes to PureQL.CSharp.Model are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning mirrors the PureQL specification with a `-csharp.N` suffix where needed.
+
+---
+
+## [Unreleased] — spec 0.1.0-preview.0.5.0
+
+Brings the C# model fully in line with PureQL specification versions
+`0.1.0-preview.0.2.0` through `0.1.0-preview.0.5.0`.
+
+### Added — spec 0.1.0-preview.0.2.0
+
+Per-row predicate family (`each*`), returning `BooleanArrayReturning`:
+
+- **`EachEquality`** — `eachEqual` for all seven comparable types
+  (`EachBooleanEquality`, `EachNumberEquality`, `EachStringEquality`,
+  `EachDateEquality`, `EachTimeEquality`, `EachDateTimeEquality`,
+  `EachUuidEquality`).
+- **`EachComparison`** — `eachGreaterThan`, `eachLessThan`,
+  `eachGreaterThanOrEqual`, `eachLessThanOrEqual` for numeric, string,
+  date, datetime, and time types. Operator values live in
+  `EachComparisonOperator` enum.
+- **`EachAndOperator`**, **`EachOrOperator`**, **`EachNotOperator`** —
+  element-wise boolean composition over `BooleanArrayReturning` operands.
+
+### Changed — spec 0.1.0-preview.0.2.0
+
+- **`BooleanArrayReturning`** extended with `EachComparison`,
+  `EachEquality`, `EachAndOperator`, `EachOrOperator`, `EachNotOperator`.
+- **`Join.On`** changed from `BooleanReturning` to
+  `OneOf<BooleanReturning, BooleanArrayReturning>`.
+- **`Query.Where`** changed from `BooleanReturning?` to
+  `OneOf<BooleanReturning, BooleanArrayReturning>?`.
+
+### Added — spec 0.1.0-preview.0.3.0
+
+Per-row numeric arithmetic, returning `NumberArrayReturning`:
+
+- **`EachArithmetic`** union — `EachAdd`, `EachSubtract`, `EachMultiply`,
+  `EachDivide`. Each accepts
+  `IEnumerable<OneOf<NumberReturning, NumberArrayReturning>>` (`minItems: 2`).
+
+Per-row date math:
+
+- **`EachDateAddDays`** — adds N days per row; left is
+  `date | dateArray`, right is `number | numberArray` →
+  `DateArrayReturning`.
+- **`EachDateDiffDays`** — date difference in days; both operands are
+  `date | dateArray` → `NumberArrayReturning`.
+
+Per-row datetime math:
+
+- **`EachDateTimeAddSeconds`** — adds N seconds per row →
+  `DateTimeArrayReturning`.
+- **`EachDateTimeDiffSeconds`** — datetime difference in seconds →
+  `NumberArrayReturning`.
+
+Per-row time math:
+
+- **`EachTimeAddSeconds`** — adds N seconds per row →
+  `TimeArrayReturning`.
+- **`EachTimeDiffSeconds`** — time difference in seconds →
+  `NumberArrayReturning`.
+
+### Changed — spec 0.1.0-preview.0.3.0
+
+- **`NumberArrayReturning`** extended with `EachArithmetic`,
+  `EachDateDiffDays`, `EachDateTimeDiffSeconds`, `EachTimeDiffSeconds`.
+- **`DateArrayReturning`** extended with `EachDateAddDays`.
+- **`TimeArrayReturning`** extended with `EachTimeAddSeconds`.
+- **`DateTimeArrayReturning`** extended with `EachDateTimeAddSeconds`.
+
+### Changed — spec 0.1.0-preview.0.4.0
+
+- `integer_equality` → `number_equality` rename in the JSON schema is
+  already reflected in the existing `NumberEquality` C# class. No code
+  change required.
+
+### Added — spec 0.1.0-preview.0.5.0
+
+- **`OrderByItem`** — wraps a `Field` reference and an optional
+  `SortDirection` (`Asc` | `Desc`, default `Asc`).
+- **`SortDirection`** enum with values `Asc` and `Desc`.
+
+### Changed — spec 0.1.0-preview.0.5.0
+
+- **`Query.OrderBy`** changed from `IEnumerable<Field>?` to
+  `IEnumerable<OrderByItem>?`. Bare field references in `orderBy` must
+  be wrapped in `OrderByItem`.
+
+### Fixed
+
+- **`NumberReturning`** now includes `Arithmetic`, `NumberAggregate`, and
+  `Count`, matching the `numericReturning` definition in the spec.
+- **`DateReturning`** now includes `DateAggregate`.
+- **`TimeReturning`** now includes `TimeAggregate`.
+- **`DateTimeReturning`** now includes `DateTimeAggregate`.
+- **`StringReturning`** now includes `StringAggregate`.
+
+---
+
+## [0.1.0-preview.0.1.0] — spec 0.1.0-preview.0.1.0
+
+Initial release aligned with PureQL specification `0.1.0-preview.0.1.0`.
+
+### Added
+
+- Core query record `Query` with `From`, `SelectExpressions`, `Where`,
+  `Join`, `GroupBy`, `Having`, `OrderBy`, `Pagination`.
+- Complete scalar type system: `StringScalar`, `NumberScalar`,
+  `BooleanScalar`, `NullScalar`, `DateScalar`, `TimeScalar`,
+  `DateTimeScalar`, `UuidScalar`.
+- Array scalar variants: `StringArrayScalar`, `NumberArrayScalar`, etc.
+- Typed fields: `StringField`, `NumberField`, `BooleanField`, `DateField`,
+  `TimeField`, `DateTimeField`, `UuidField`. `Field` union wraps all.
+- Typed parameters and array parameters.
+- `FromExpression` (entity + alias), `Pagination` (skip + take).
+- `SelectExpression` — either `SingleValueReturning` or `ArrayReturning`
+  with optional alias.
+- Typed returnings: `BooleanReturning`, `NumberReturning`,
+  `StringReturning`, `DateReturning`, `TimeReturning`, `DateTimeReturning`,
+  `UuidReturning`. Array variants: `BooleanArrayReturning`,
+  `NumberArrayReturning`, etc.
+- Single-value arithmetic: `Add`, `Subtract`, `Multiply`, `Divide`
+  wrapped in `Arithmetic`.
+- Boolean operators: `AndOperator`, `OrOperator`, `NotOperator`.
+- Single-value equalities: `BooleanEquality`, `NumberEquality`,
+  `StringEquality`, `DateEquality`, `TimeEquality`, `DateTimeEquality`,
+  `UuidEquality` wrapped in `SingleValueEquality`.
+- Array equalities: `BooleanArrayEquality`, `NumberArrayEquality`, etc.
+  wrapped in `ArrayEquality`.
+- Single-value comparisons: `NumberComparison`, `StringComparison`,
+  `DateComparison`, `TimeComparison`, `DateTimeComparison`. Operator values
+  in `ComparisonOperator` enum.
+- Aggregates: `Count`, `NumberAggregate` (`Sum`, `Min`, `Max`,
+  `Average`), `StringAggregate`, `DateAggregate`, `TimeAggregate`,
+  `DateTimeAggregate`.
+- `JoinType` enum (`Inner`, `Left`, `Right`, `Full`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning mirrors the PureQL specification with a `-csharp.N` suffix where need
 
 ---
 
-## [Unreleased] — spec 0.1.0-preview.0.5.0
+## [0.1.0-preview.11.0.0] — spec 0.1.0-preview.0.5.0
 
 Brings the C# model fully in line with PureQL specification versions
 `0.1.0-preview.0.2.0` through `0.1.0-preview.0.5.0`.
@@ -106,43 +106,3 @@ Per-row time math:
   matching the spec where `alias` is not in the `required` array.
 - **`Query.Distinct`** property added (`bool`, default `false`), matching the
   `distinct` property defined at the root query level in the spec.
-
----
-
-## [0.1.0-preview.0.1.0] — spec 0.1.0-preview.0.1.0
-
-Initial release aligned with PureQL specification `0.1.0-preview.0.1.0`.
-
-### Added
-
-- Core query record `Query` with `From`, `SelectExpressions`, `Where`,
-  `Join`, `GroupBy`, `Having`, `OrderBy`, `Pagination`.
-- Complete scalar type system: `StringScalar`, `NumberScalar`,
-  `BooleanScalar`, `NullScalar`, `DateScalar`, `TimeScalar`,
-  `DateTimeScalar`, `UuidScalar`.
-- Array scalar variants: `StringArrayScalar`, `NumberArrayScalar`, etc.
-- Typed fields: `StringField`, `NumberField`, `BooleanField`, `DateField`,
-  `TimeField`, `DateTimeField`, `UuidField`. `Field` union wraps all.
-- Typed parameters and array parameters.
-- `FromExpression` (entity + alias), `Pagination` (skip + take).
-- `SelectExpression` — either `SingleValueReturning` or `ArrayReturning`
-  with optional alias.
-- Typed returnings: `BooleanReturning`, `NumberReturning`,
-  `StringReturning`, `DateReturning`, `TimeReturning`, `DateTimeReturning`,
-  `UuidReturning`. Array variants: `BooleanArrayReturning`,
-  `NumberArrayReturning`, etc.
-- Single-value arithmetic: `Add`, `Subtract`, `Multiply`, `Divide`
-  wrapped in `Arithmetic`.
-- Boolean operators: `AndOperator`, `OrOperator`, `NotOperator`.
-- Single-value equalities: `BooleanEquality`, `NumberEquality`,
-  `StringEquality`, `DateEquality`, `TimeEquality`, `DateTimeEquality`,
-  `UuidEquality` wrapped in `SingleValueEquality`.
-- Array equalities: `BooleanArrayEquality`, `NumberArrayEquality`, etc.
-  wrapped in `ArrayEquality`.
-- Single-value comparisons: `NumberComparison`, `StringComparison`,
-  `DateComparison`, `TimeComparison`, `DateTimeComparison`. Operator values
-  in `ComparisonOperator` enum.
-- Aggregates: `Count`, `NumberAggregate` (`Sum`, `Min`, `Max`,
-  `Average`), `StringAggregate`, `DateAggregate`, `TimeAggregate`,
-  `DateTimeAggregate`.
-- `JoinType` enum (`Inner`, `Left`, `Right`, `Full`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,12 @@ Per-row time math:
 - **`TimeReturning`** now includes `TimeAggregate`.
 - **`DateTimeReturning`** now includes `DateTimeAggregate`.
 - **`StringReturning`** now includes `StringAggregate`.
+- **`NullField`** added and included as the 8th variant in the `Field` union,
+  matching the `nullField` entry in the spec's `field` definition.
+- **`FromExpression.Alias`** is now optional (`string?` with default `null`),
+  matching the spec where `alias` is not in the `required` array.
+- **`Query.Distinct`** property added (`bool`, default `false`), matching the
+  `distinct` property defined at the root query level in the spec.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,219 @@
+# PureQL.CSharp.Model
+
+C# model library for [PureQL](https://github.com/kudima03/PureQL-Specification) — a JSON-based query language. Provides strongly-typed .NET record and discriminated-union types that mirror the PureQL JSON Schema, enabling construction, inspection, and serialisation of PureQL queries in C#.
+
+**Current specification version:** `0.1.0-preview.0.5.0`
+
+---
+
+## Installation
+
+```
+dotnet add package PureQL.CSharp.Model
+```
+
+Targets: .NET 6, 7, 8, 9, 10.
+
+---
+
+## Core concepts
+
+A `Query` carries:
+
+| Property | Type | Required |
+|---|---|---|
+| `From` | `FromExpression` | yes |
+| `SelectExpressions` | `IEnumerable<SelectExpression>` | yes |
+| `Where` | `OneOf<BooleanReturning, BooleanArrayReturning>?` | no |
+| `Join` | `IEnumerable<Join>?` | no |
+| `GroupBy` | `IEnumerable<Field>?` | no |
+| `Having` | `BooleanReturning?` | no |
+| `OrderBy` | `IEnumerable<OrderByItem>?` | no |
+| `Pagination` | `Pagination?` | no |
+
+### Discriminated unions via OneOf
+
+All polymorphic positions use `OneOf` / `OneOfBase<…>` from the [OneOf](https://github.com/mcintyre321/OneOf) package. For example `BooleanReturning` is a union of `BooleanScalar | BooleanParameter | Equality | BooleanOperator | Comparison`.
+
+---
+
+## Type system
+
+### Scalar types
+
+| C# class | JSON name |
+|---|---|
+| `StringScalar` | `string` |
+| `NumberScalar` | `number` |
+| `BooleanScalar` | `boolean` |
+| `DateScalar` | `date` |
+| `TimeScalar` | `time` |
+| `DateTimeScalar` | `datetime` |
+| `UuidScalar` | `uuid` |
+| `NullScalar` | `null` |
+
+### Field references
+
+Each typed field (`StringField`, `NumberField`, `DateField`, …) holds `Entity` and `Field` strings. The `Field` union wraps all typed fields.
+
+### Parameters
+
+Named parameters (`StringParameter`, `NumberParameter`, …) identify runtime-provided values by `ParamName`.
+
+### Array variants
+
+Array versions of scalars, fields, and parameters exist in `ArrayScalars`, `Fields`, and `ArrayParameters` namespaces respectively.
+
+---
+
+## Operators
+
+### Single-value boolean family
+
+| Operator | C# type |
+|---|---|
+| `and` / `or` / `not` | `AndOperator`, `OrOperator`, `NotOperator` |
+| `equal` (single-value) | `SingleValueEquality` → typed equalities |
+| `equal` (array) | `ArrayEquality` → typed array equalities |
+| `greaterThan` / `lessThan` / … | `Comparison` → typed comparisons |
+
+### Per-row predicate family (`each*`)
+
+Per-row operators return `BooleanArrayReturning` — a per-row boolean column.
+
+| Operator | C# type |
+|---|---|
+| `eachEqual` | `EachEquality` (7 typed variants) |
+| `eachGreaterThan` / `eachLessThan` / … | `EachComparison` (5 typed variants) |
+| `eachAnd` / `eachOr` / `eachNot` | `EachAndOperator`, `EachOrOperator`, `EachNotOperator` |
+
+### Single-value arithmetic
+
+| Operator | C# type |
+|---|---|
+| `add` / `subtract` / `multiply` / `divide` | `Arithmetic` → `Add`, `Subtract`, `Multiply`, `Divide` |
+
+### Per-row arithmetic (`each*`)
+
+Per-row arithmetic operators accept mixed `numericReturning | numericArrayReturning` operands and return `NumberArrayReturning`.
+
+| Operator | C# type |
+|---|---|
+| `eachAdd` / `eachSubtract` / `eachMultiply` / `eachDivide` | `EachArithmetic` → `EachAdd`, `EachSubtract`, `EachMultiply`, `EachDivide` |
+
+### Per-row date / time / datetime math
+
+| Operator | Return type | C# type |
+|---|---|---|
+| `eachDateAddDays` | `DateArrayReturning` | `EachDateAddDays` |
+| `eachDateDiffDays` | `NumberArrayReturning` | `EachDateDiffDays` |
+| `eachDatetimeAddSeconds` | `DateTimeArrayReturning` | `EachDateTimeAddSeconds` |
+| `eachDatetimeDiffSeconds` | `NumberArrayReturning` | `EachDateTimeDiffSeconds` |
+| `eachTimeAddSeconds` | `TimeArrayReturning` | `EachTimeAddSeconds` |
+| `eachTimeDiffSeconds` | `NumberArrayReturning` | `EachTimeDiffSeconds` |
+
+### Aggregates
+
+| Operator | C# type |
+|---|---|
+| `count` | `Count` |
+| `sum` / `average_number` / `min_number` / `max_number` | `NumberAggregate` |
+| `min_string` / `max_string` | `StringAggregate` |
+| `min_date` / `max_date` / `average_date` | `DateAggregate` |
+| `min_time` / `max_time` / `average_time` | `TimeAggregate` |
+| `min_datetime` / `max_datetime` / `average_datetime` | `DateTimeAggregate` |
+
+---
+
+## OrderBy with direction
+
+`OrderByItem` wraps a field reference and an optional sort direction:
+
+```csharp
+var orderBy = new[]
+{
+    new OrderByItem(new Field(new NumberField("orders", "amount")), SortDirection.Desc),
+    new OrderByItem(new Field(new StringField("orders", "name"))),  // defaults to Asc
+};
+```
+
+`SortDirection` is an enum with values `Asc` and `Desc`.
+
+---
+
+## Usage example
+
+```csharp
+// SELECT u.id, COUNT(o.id) AS order_count
+// FROM users AS u
+// INNER JOIN orders AS o ON u.id = o.user_id
+// WHERE u.status = 'active'
+// GROUP BY u.id
+// ORDER BY order_count DESC
+// LIMIT 20 OFFSET 0
+
+var usersFrom = new FromExpression("users", "u");
+
+var userIdField = new NumberField("users", "id");
+var orderIdField = new NumberField("orders", "id");
+var userStatusField = new StringField("users", "status");
+var orderUserIdField = new NumberField("orders", "user_id");
+
+var select = new[]
+{
+    new SelectExpression(new ArrayReturning(new NumberArrayReturning(userIdField))),
+    new SelectExpression(
+        new SingleValueReturning(
+            new NumberReturning(
+                new Count(new ArrayReturning(new NumberArrayReturning(orderIdField)))
+            )
+        ),
+        "order_count"
+    ),
+};
+
+var join = new Join(
+    JoinType.Inner,
+    "orders",
+    new BooleanArrayReturning(
+        new EachEquality(
+            new EachNumberEquality(
+                new NumberArrayReturning(userIdField),
+                OneOf<NumberReturning, NumberArrayReturning>.FromT1(
+                    new NumberArrayReturning(orderUserIdField)
+                )
+            )
+        )
+    )
+);
+
+var where = OneOf<BooleanReturning, BooleanArrayReturning>.FromT1(
+    new BooleanArrayReturning(
+        new EachEquality(
+            new EachStringEquality(
+                new StringArrayReturning(userStatusField),
+                OneOf<StringReturning, StringArrayReturning>.FromT0(
+                    new StringReturning(new StringScalar("active"))
+                )
+            )
+        )
+    )
+);
+
+var query = new Query(
+    from: usersFrom,
+    selectExpressions: select,
+    where: where,
+    join: new[] { join },
+    groupBy: new[] { new Field(userIdField) },
+    having: null,
+    orderBy: new[] { new OrderByItem(new Field(new NumberField("orders", "order_count")), SortDirection.Desc) },
+    pagination: new Pagination(0, 20)
+);
+```
+
+---
+
+## License
+
+[MIT](LICENSE)

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -66,6 +66,7 @@ dotnet_diagnostic.CA1716.severity = none
 dotnet_diagnostic.CA1859.severity = none
 dotnet_diagnostic.CA1305.severity = none
 dotnet_diagnostic.CA1720.severity = none
+dotnet_diagnostic.IDE0370.severity = none
 ##########################################
 # Language Rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules

--- a/src/PureQL.CSharp.Model/ArrayReturnings/BooleanArrayReturning.cs
+++ b/src/PureQL.CSharp.Model/ArrayReturnings/BooleanArrayReturning.cs
@@ -1,25 +1,164 @@
 using OneOf;
 using PureQL.CSharp.Model.ArrayParameters;
 using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.EachBooleanOperations;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachEqualities;
 using PureQL.CSharp.Model.Fields;
 
 namespace PureQL.CSharp.Model.ArrayReturnings;
 
 public sealed class BooleanArrayReturning
-    : OneOfBase<BooleanArrayScalar, BooleanField, BooleanArrayParameter>
+    : OneOfBase<
+        BooleanArrayScalar,
+        BooleanField,
+        BooleanArrayParameter,
+        EachComparison,
+        EachEquality,
+        EachAndOperator,
+        EachOrOperator,
+        EachNotOperator
+    >
 {
     public BooleanArrayReturning(BooleanArrayScalar scalar)
-        : this((OneOf<BooleanArrayScalar, BooleanField, BooleanArrayParameter>)scalar) { }
+        : this(
+            (OneOf<
+                BooleanArrayScalar,
+                BooleanField,
+                BooleanArrayParameter,
+                EachComparison,
+                EachEquality,
+                EachAndOperator,
+                EachOrOperator,
+                EachNotOperator
+            >)
+                scalar
+        )
+    { }
 
     public BooleanArrayReturning(BooleanField field)
-        : this((OneOf<BooleanArrayScalar, BooleanField, BooleanArrayParameter>)field) { }
+        : this(
+            (OneOf<
+                BooleanArrayScalar,
+                BooleanField,
+                BooleanArrayParameter,
+                EachComparison,
+                EachEquality,
+                EachAndOperator,
+                EachOrOperator,
+                EachNotOperator
+            >)
+                field
+        )
+    { }
 
     public BooleanArrayReturning(BooleanArrayParameter parameter)
-        : this((OneOf<BooleanArrayScalar, BooleanField, BooleanArrayParameter>)parameter)
+        : this(
+            (OneOf<
+                BooleanArrayScalar,
+                BooleanField,
+                BooleanArrayParameter,
+                EachComparison,
+                EachEquality,
+                EachAndOperator,
+                EachOrOperator,
+                EachNotOperator
+            >)
+                parameter
+        )
+    { }
+
+    public BooleanArrayReturning(EachComparison comparison)
+        : this(
+            (OneOf<
+                BooleanArrayScalar,
+                BooleanField,
+                BooleanArrayParameter,
+                EachComparison,
+                EachEquality,
+                EachAndOperator,
+                EachOrOperator,
+                EachNotOperator
+            >)
+                comparison
+        )
+    { }
+
+    public BooleanArrayReturning(EachEquality equality)
+        : this(
+            (OneOf<
+                BooleanArrayScalar,
+                BooleanField,
+                BooleanArrayParameter,
+                EachComparison,
+                EachEquality,
+                EachAndOperator,
+                EachOrOperator,
+                EachNotOperator
+            >)
+                equality
+        )
+    { }
+
+    public BooleanArrayReturning(EachAndOperator @operator)
+        : this(
+            (OneOf<
+                BooleanArrayScalar,
+                BooleanField,
+                BooleanArrayParameter,
+                EachComparison,
+                EachEquality,
+                EachAndOperator,
+                EachOrOperator,
+                EachNotOperator
+            >)
+                @operator
+        )
+    { }
+
+    public BooleanArrayReturning(EachOrOperator @operator)
+        : this(
+            (OneOf<
+                BooleanArrayScalar,
+                BooleanField,
+                BooleanArrayParameter,
+                EachComparison,
+                EachEquality,
+                EachAndOperator,
+                EachOrOperator,
+                EachNotOperator
+            >)
+                @operator
+        )
+    { }
+
+    public BooleanArrayReturning(EachNotOperator @operator)
+        : this(
+            (OneOf<
+                BooleanArrayScalar,
+                BooleanField,
+                BooleanArrayParameter,
+                EachComparison,
+                EachEquality,
+                EachAndOperator,
+                EachOrOperator,
+                EachNotOperator
+            >)
+                @operator
+        )
     { }
 
     private BooleanArrayReturning(
-        OneOf<BooleanArrayScalar, BooleanField, BooleanArrayParameter> input
+        OneOf<
+            BooleanArrayScalar,
+            BooleanField,
+            BooleanArrayParameter,
+            EachComparison,
+            EachEquality,
+            EachAndOperator,
+            EachOrOperator,
+            EachNotOperator
+        > input
     )
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/ArrayReturnings/DateArrayReturning.cs
+++ b/src/PureQL.CSharp.Model/ArrayReturnings/DateArrayReturning.cs
@@ -1,24 +1,37 @@
 using OneOf;
 using PureQL.CSharp.Model.ArrayParameters;
 using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.EachDateArithmetics;
 using PureQL.CSharp.Model.Fields;
 
 namespace PureQL.CSharp.Model.ArrayReturnings;
 
 public sealed class DateArrayReturning
-    : OneOfBase<DateArrayParameter, DateField, DateArrayScalar>
+    : OneOfBase<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>
 {
     public DateArrayReturning(DateArrayParameter parameter)
-        : this((OneOf<DateArrayParameter, DateField, DateArrayScalar>)parameter) { }
+        : this(
+            (OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)parameter
+        )
+    { }
 
     public DateArrayReturning(DateField field)
-        : this((OneOf<DateArrayParameter, DateField, DateArrayScalar>)field) { }
+        : this((OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)field) { }
 
     public DateArrayReturning(DateArrayScalar scalar)
-        : this((OneOf<DateArrayParameter, DateField, DateArrayScalar>)scalar) { }
+        : this(
+            (OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)scalar
+        )
+    { }
+
+    public DateArrayReturning(EachDateAddDays addDays)
+        : this(
+            (OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)addDays
+        )
+    { }
 
     private DateArrayReturning(
-        OneOf<DateArrayParameter, DateField, DateArrayScalar> input
+        OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays> input
     )
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/ArrayReturnings/DateArrayReturning.cs
+++ b/src/PureQL.CSharp.Model/ArrayReturnings/DateArrayReturning.cs
@@ -11,12 +11,16 @@ public sealed class DateArrayReturning
 {
     public DateArrayReturning(DateArrayParameter parameter)
         : this(
-            (OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)parameter
+            (OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)
+                parameter
         )
     { }
 
     public DateArrayReturning(DateField field)
-        : this((OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)field) { }
+        : this(
+            (OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)field
+        )
+    { }
 
     public DateArrayReturning(DateArrayScalar scalar)
         : this(
@@ -26,7 +30,8 @@ public sealed class DateArrayReturning
 
     public DateArrayReturning(EachDateAddDays addDays)
         : this(
-            (OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)addDays
+            (OneOf<DateArrayParameter, DateField, DateArrayScalar, EachDateAddDays>)
+                addDays
         )
     { }
 

--- a/src/PureQL.CSharp.Model/ArrayReturnings/DateTimeArrayReturning.cs
+++ b/src/PureQL.CSharp.Model/ArrayReturnings/DateTimeArrayReturning.cs
@@ -16,30 +16,59 @@ public sealed class DateTimeArrayReturning
 {
     public DateTimeArrayReturning(DateTimeArrayParameter parameter)
         : this(
-            (OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds>)parameter
+            (OneOf<
+                DateTimeArrayParameter,
+                DateTimeField,
+                DateTimeArrayScalar,
+                EachDateTimeAddSeconds
+            >)
+                parameter
         )
     { }
 
     public DateTimeArrayReturning(DateTimeField field)
         : this(
-            (OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds>)field
+            (OneOf<
+                DateTimeArrayParameter,
+                DateTimeField,
+                DateTimeArrayScalar,
+                EachDateTimeAddSeconds
+            >)
+                field
         )
     { }
 
     public DateTimeArrayReturning(DateTimeArrayScalar scalar)
         : this(
-            (OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds>)scalar
+            (OneOf<
+                DateTimeArrayParameter,
+                DateTimeField,
+                DateTimeArrayScalar,
+                EachDateTimeAddSeconds
+            >)
+                scalar
         )
     { }
 
     public DateTimeArrayReturning(EachDateTimeAddSeconds addSeconds)
         : this(
-            (OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds>)addSeconds
+            (OneOf<
+                DateTimeArrayParameter,
+                DateTimeField,
+                DateTimeArrayScalar,
+                EachDateTimeAddSeconds
+            >)
+                addSeconds
         )
     { }
 
     private DateTimeArrayReturning(
-        OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds> input
+        OneOf<
+            DateTimeArrayParameter,
+            DateTimeField,
+            DateTimeArrayScalar,
+            EachDateTimeAddSeconds
+        > input
     )
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/ArrayReturnings/DateTimeArrayReturning.cs
+++ b/src/PureQL.CSharp.Model/ArrayReturnings/DateTimeArrayReturning.cs
@@ -1,29 +1,45 @@
 using OneOf;
 using PureQL.CSharp.Model.ArrayParameters;
 using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.EachDateTimeArithmetics;
 using PureQL.CSharp.Model.Fields;
 
 namespace PureQL.CSharp.Model.ArrayReturnings;
 
 public sealed class DateTimeArrayReturning
-    : OneOfBase<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar>
+    : OneOfBase<
+        DateTimeArrayParameter,
+        DateTimeField,
+        DateTimeArrayScalar,
+        EachDateTimeAddSeconds
+    >
 {
     public DateTimeArrayReturning(DateTimeArrayParameter parameter)
         : this(
-            (OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar>)parameter
+            (OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds>)parameter
         )
     { }
 
     public DateTimeArrayReturning(DateTimeField field)
-        : this((OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar>)field)
+        : this(
+            (OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds>)field
+        )
     { }
 
     public DateTimeArrayReturning(DateTimeArrayScalar scalar)
-        : this((OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar>)scalar)
+        : this(
+            (OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds>)scalar
+        )
+    { }
+
+    public DateTimeArrayReturning(EachDateTimeAddSeconds addSeconds)
+        : this(
+            (OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds>)addSeconds
+        )
     { }
 
     private DateTimeArrayReturning(
-        OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar> input
+        OneOf<DateTimeArrayParameter, DateTimeField, DateTimeArrayScalar, EachDateTimeAddSeconds> input
     )
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/ArrayReturnings/NumberArrayReturning.cs
+++ b/src/PureQL.CSharp.Model/ArrayReturnings/NumberArrayReturning.cs
@@ -1,24 +1,140 @@
 using OneOf;
 using PureQL.CSharp.Model.ArrayParameters;
 using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.EachArithmetics;
+using PureQL.CSharp.Model.EachDateArithmetics;
+using PureQL.CSharp.Model.EachDateTimeArithmetics;
+using PureQL.CSharp.Model.EachTimeArithmetics;
 using PureQL.CSharp.Model.Fields;
 
 namespace PureQL.CSharp.Model.ArrayReturnings;
 
 public sealed class NumberArrayReturning
-    : OneOfBase<NumberArrayParameter, NumberField, NumberArrayScalar>
+    : OneOfBase<
+        NumberArrayParameter,
+        NumberField,
+        NumberArrayScalar,
+        EachArithmetic,
+        EachDateDiffDays,
+        EachDateTimeDiffSeconds,
+        EachTimeDiffSeconds
+    >
 {
     public NumberArrayReturning(NumberArrayParameter parameter)
-        : this((OneOf<NumberArrayParameter, NumberField, NumberArrayScalar>)parameter) { }
+        : this(
+            (OneOf<
+                NumberArrayParameter,
+                NumberField,
+                NumberArrayScalar,
+                EachArithmetic,
+                EachDateDiffDays,
+                EachDateTimeDiffSeconds,
+                EachTimeDiffSeconds
+            >)
+                parameter
+        )
+    { }
 
     public NumberArrayReturning(NumberField field)
-        : this((OneOf<NumberArrayParameter, NumberField, NumberArrayScalar>)field) { }
+        : this(
+            (OneOf<
+                NumberArrayParameter,
+                NumberField,
+                NumberArrayScalar,
+                EachArithmetic,
+                EachDateDiffDays,
+                EachDateTimeDiffSeconds,
+                EachTimeDiffSeconds
+            >)
+                field
+        )
+    { }
 
     public NumberArrayReturning(NumberArrayScalar scalar)
-        : this((OneOf<NumberArrayParameter, NumberField, NumberArrayScalar>)scalar) { }
+        : this(
+            (OneOf<
+                NumberArrayParameter,
+                NumberField,
+                NumberArrayScalar,
+                EachArithmetic,
+                EachDateDiffDays,
+                EachDateTimeDiffSeconds,
+                EachTimeDiffSeconds
+            >)
+                scalar
+        )
+    { }
+
+    public NumberArrayReturning(EachArithmetic arithmetic)
+        : this(
+            (OneOf<
+                NumberArrayParameter,
+                NumberField,
+                NumberArrayScalar,
+                EachArithmetic,
+                EachDateDiffDays,
+                EachDateTimeDiffSeconds,
+                EachTimeDiffSeconds
+            >)
+                arithmetic
+        )
+    { }
+
+    public NumberArrayReturning(EachDateDiffDays diff)
+        : this(
+            (OneOf<
+                NumberArrayParameter,
+                NumberField,
+                NumberArrayScalar,
+                EachArithmetic,
+                EachDateDiffDays,
+                EachDateTimeDiffSeconds,
+                EachTimeDiffSeconds
+            >)
+                diff
+        )
+    { }
+
+    public NumberArrayReturning(EachDateTimeDiffSeconds diff)
+        : this(
+            (OneOf<
+                NumberArrayParameter,
+                NumberField,
+                NumberArrayScalar,
+                EachArithmetic,
+                EachDateDiffDays,
+                EachDateTimeDiffSeconds,
+                EachTimeDiffSeconds
+            >)
+                diff
+        )
+    { }
+
+    public NumberArrayReturning(EachTimeDiffSeconds diff)
+        : this(
+            (OneOf<
+                NumberArrayParameter,
+                NumberField,
+                NumberArrayScalar,
+                EachArithmetic,
+                EachDateDiffDays,
+                EachDateTimeDiffSeconds,
+                EachTimeDiffSeconds
+            >)
+                diff
+        )
+    { }
 
     private NumberArrayReturning(
-        OneOf<NumberArrayParameter, NumberField, NumberArrayScalar> input
+        OneOf<
+            NumberArrayParameter,
+            NumberField,
+            NumberArrayScalar,
+            EachArithmetic,
+            EachDateDiffDays,
+            EachDateTimeDiffSeconds,
+            EachTimeDiffSeconds
+        > input
     )
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/ArrayReturnings/TimeArrayReturning.cs
+++ b/src/PureQL.CSharp.Model/ArrayReturnings/TimeArrayReturning.cs
@@ -11,25 +11,29 @@ public sealed class TimeArrayReturning
 {
     public TimeArrayReturning(TimeArrayParameter parameter)
         : this(
-            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)parameter
+            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)
+                parameter
         )
     { }
 
     public TimeArrayReturning(TimeField field)
         : this(
-            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)field
+            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)
+                field
         )
     { }
 
     public TimeArrayReturning(TimeArrayScalar scalar)
         : this(
-            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)scalar
+            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)
+                scalar
         )
     { }
 
     public TimeArrayReturning(EachTimeAddSeconds addSeconds)
         : this(
-            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)addSeconds
+            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)
+                addSeconds
         )
     { }
 

--- a/src/PureQL.CSharp.Model/ArrayReturnings/TimeArrayReturning.cs
+++ b/src/PureQL.CSharp.Model/ArrayReturnings/TimeArrayReturning.cs
@@ -1,24 +1,40 @@
 using OneOf;
 using PureQL.CSharp.Model.ArrayParameters;
 using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.EachTimeArithmetics;
 using PureQL.CSharp.Model.Fields;
 
 namespace PureQL.CSharp.Model.ArrayReturnings;
 
 public sealed class TimeArrayReturning
-    : OneOfBase<TimeArrayParameter, TimeField, TimeArrayScalar>
+    : OneOfBase<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>
 {
     public TimeArrayReturning(TimeArrayParameter parameter)
-        : this((OneOf<TimeArrayParameter, TimeField, TimeArrayScalar>)parameter) { }
+        : this(
+            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)parameter
+        )
+    { }
 
     public TimeArrayReturning(TimeField field)
-        : this((OneOf<TimeArrayParameter, TimeField, TimeArrayScalar>)field) { }
+        : this(
+            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)field
+        )
+    { }
 
     public TimeArrayReturning(TimeArrayScalar scalar)
-        : this((OneOf<TimeArrayParameter, TimeField, TimeArrayScalar>)scalar) { }
+        : this(
+            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)scalar
+        )
+    { }
+
+    public TimeArrayReturning(EachTimeAddSeconds addSeconds)
+        : this(
+            (OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds>)addSeconds
+        )
+    { }
 
     private TimeArrayReturning(
-        OneOf<TimeArrayParameter, TimeField, TimeArrayScalar> input
+        OneOf<TimeArrayParameter, TimeField, TimeArrayScalar, EachTimeAddSeconds> input
     )
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/EachArithmetics/EachAdd.cs
+++ b/src/PureQL.CSharp.Model/EachArithmetics/EachAdd.cs
@@ -1,0 +1,15 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachArithmetics;
+
+public sealed record EachAdd
+{
+    public EachAdd(IEnumerable<OneOf<NumberReturning, NumberArrayReturning>> values)
+    {
+        Values = values;
+    }
+
+    public IEnumerable<OneOf<NumberReturning, NumberArrayReturning>> Values { get; }
+}

--- a/src/PureQL.CSharp.Model/EachArithmetics/EachArithmetic.cs
+++ b/src/PureQL.CSharp.Model/EachArithmetics/EachArithmetic.cs
@@ -1,0 +1,21 @@
+using OneOf;
+
+namespace PureQL.CSharp.Model.EachArithmetics;
+
+public sealed class EachArithmetic : OneOfBase<EachAdd, EachSubtract, EachMultiply, EachDivide>
+{
+    public EachArithmetic(EachAdd add)
+        : this((OneOf<EachAdd, EachSubtract, EachMultiply, EachDivide>)add) { }
+
+    public EachArithmetic(EachSubtract subtract)
+        : this((OneOf<EachAdd, EachSubtract, EachMultiply, EachDivide>)subtract) { }
+
+    public EachArithmetic(EachMultiply multiply)
+        : this((OneOf<EachAdd, EachSubtract, EachMultiply, EachDivide>)multiply) { }
+
+    public EachArithmetic(EachDivide divide)
+        : this((OneOf<EachAdd, EachSubtract, EachMultiply, EachDivide>)divide) { }
+
+    private EachArithmetic(OneOf<EachAdd, EachSubtract, EachMultiply, EachDivide> input)
+        : base(input) { }
+}

--- a/src/PureQL.CSharp.Model/EachArithmetics/EachArithmetic.cs
+++ b/src/PureQL.CSharp.Model/EachArithmetics/EachArithmetic.cs
@@ -2,7 +2,8 @@ using OneOf;
 
 namespace PureQL.CSharp.Model.EachArithmetics;
 
-public sealed class EachArithmetic : OneOfBase<EachAdd, EachSubtract, EachMultiply, EachDivide>
+public sealed class EachArithmetic
+    : OneOfBase<EachAdd, EachSubtract, EachMultiply, EachDivide>
 {
     public EachArithmetic(EachAdd add)
         : this((OneOf<EachAdd, EachSubtract, EachMultiply, EachDivide>)add) { }

--- a/src/PureQL.CSharp.Model/EachArithmetics/EachDivide.cs
+++ b/src/PureQL.CSharp.Model/EachArithmetics/EachDivide.cs
@@ -1,0 +1,15 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachArithmetics;
+
+public sealed record EachDivide
+{
+    public EachDivide(IEnumerable<OneOf<NumberReturning, NumberArrayReturning>> values)
+    {
+        Values = values;
+    }
+
+    public IEnumerable<OneOf<NumberReturning, NumberArrayReturning>> Values { get; }
+}

--- a/src/PureQL.CSharp.Model/EachArithmetics/EachMultiply.cs
+++ b/src/PureQL.CSharp.Model/EachArithmetics/EachMultiply.cs
@@ -1,0 +1,15 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachArithmetics;
+
+public sealed record EachMultiply
+{
+    public EachMultiply(IEnumerable<OneOf<NumberReturning, NumberArrayReturning>> values)
+    {
+        Values = values;
+    }
+
+    public IEnumerable<OneOf<NumberReturning, NumberArrayReturning>> Values { get; }
+}

--- a/src/PureQL.CSharp.Model/EachArithmetics/EachSubtract.cs
+++ b/src/PureQL.CSharp.Model/EachArithmetics/EachSubtract.cs
@@ -1,0 +1,15 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachArithmetics;
+
+public sealed record EachSubtract
+{
+    public EachSubtract(IEnumerable<OneOf<NumberReturning, NumberArrayReturning>> values)
+    {
+        Values = values;
+    }
+
+    public IEnumerable<OneOf<NumberReturning, NumberArrayReturning>> Values { get; }
+}

--- a/src/PureQL.CSharp.Model/EachBooleanOperations/EachAndOperator.cs
+++ b/src/PureQL.CSharp.Model/EachBooleanOperations/EachAndOperator.cs
@@ -1,0 +1,13 @@
+using PureQL.CSharp.Model.ArrayReturnings;
+
+namespace PureQL.CSharp.Model.EachBooleanOperations;
+
+public sealed record EachAndOperator
+{
+    public EachAndOperator(IEnumerable<BooleanArrayReturning> conditions)
+    {
+        Conditions = conditions;
+    }
+
+    public IEnumerable<BooleanArrayReturning> Conditions { get; }
+}

--- a/src/PureQL.CSharp.Model/EachBooleanOperations/EachBooleanOperator.cs
+++ b/src/PureQL.CSharp.Model/EachBooleanOperations/EachBooleanOperator.cs
@@ -2,7 +2,8 @@ using OneOf;
 
 namespace PureQL.CSharp.Model.EachBooleanOperations;
 
-public sealed class EachBooleanOperator : OneOfBase<EachAndOperator, EachOrOperator, EachNotOperator>
+public sealed class EachBooleanOperator
+    : OneOfBase<EachAndOperator, EachOrOperator, EachNotOperator>
 {
     public EachBooleanOperator(EachAndOperator @operator)
         : this((OneOf<EachAndOperator, EachOrOperator, EachNotOperator>)@operator) { }
@@ -13,6 +14,8 @@ public sealed class EachBooleanOperator : OneOfBase<EachAndOperator, EachOrOpera
     public EachBooleanOperator(EachNotOperator @operator)
         : this((OneOf<EachAndOperator, EachOrOperator, EachNotOperator>)@operator) { }
 
-    private EachBooleanOperator(OneOf<EachAndOperator, EachOrOperator, EachNotOperator> input)
+    private EachBooleanOperator(
+        OneOf<EachAndOperator, EachOrOperator, EachNotOperator> input
+    )
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/EachBooleanOperations/EachBooleanOperator.cs
+++ b/src/PureQL.CSharp.Model/EachBooleanOperations/EachBooleanOperator.cs
@@ -1,0 +1,18 @@
+using OneOf;
+
+namespace PureQL.CSharp.Model.EachBooleanOperations;
+
+public sealed class EachBooleanOperator : OneOfBase<EachAndOperator, EachOrOperator, EachNotOperator>
+{
+    public EachBooleanOperator(EachAndOperator @operator)
+        : this((OneOf<EachAndOperator, EachOrOperator, EachNotOperator>)@operator) { }
+
+    public EachBooleanOperator(EachOrOperator @operator)
+        : this((OneOf<EachAndOperator, EachOrOperator, EachNotOperator>)@operator) { }
+
+    public EachBooleanOperator(EachNotOperator @operator)
+        : this((OneOf<EachAndOperator, EachOrOperator, EachNotOperator>)@operator) { }
+
+    private EachBooleanOperator(OneOf<EachAndOperator, EachOrOperator, EachNotOperator> input)
+        : base(input) { }
+}

--- a/src/PureQL.CSharp.Model/EachBooleanOperations/EachNotOperator.cs
+++ b/src/PureQL.CSharp.Model/EachBooleanOperations/EachNotOperator.cs
@@ -1,0 +1,13 @@
+using PureQL.CSharp.Model.ArrayReturnings;
+
+namespace PureQL.CSharp.Model.EachBooleanOperations;
+
+public sealed record EachNotOperator
+{
+    public EachNotOperator(BooleanArrayReturning condition)
+    {
+        Condition = condition;
+    }
+
+    public BooleanArrayReturning Condition { get; }
+}

--- a/src/PureQL.CSharp.Model/EachBooleanOperations/EachOrOperator.cs
+++ b/src/PureQL.CSharp.Model/EachBooleanOperations/EachOrOperator.cs
@@ -1,0 +1,13 @@
+using PureQL.CSharp.Model.ArrayReturnings;
+
+namespace PureQL.CSharp.Model.EachBooleanOperations;
+
+public sealed record EachOrOperator
+{
+    public EachOrOperator(IEnumerable<BooleanArrayReturning> conditions)
+    {
+        Conditions = conditions;
+    }
+
+    public IEnumerable<BooleanArrayReturning> Conditions { get; }
+}

--- a/src/PureQL.CSharp.Model/EachComparisons/EachComparison.cs
+++ b/src/PureQL.CSharp.Model/EachComparisons/EachComparison.cs
@@ -1,0 +1,89 @@
+using OneOf;
+
+namespace PureQL.CSharp.Model.EachComparisons;
+
+public sealed class EachComparison
+    : OneOfBase<
+        EachNumberComparison,
+        EachStringComparison,
+        EachDateComparison,
+        EachDateTimeComparison,
+        EachTimeComparison
+    >
+{
+    public EachComparison(EachNumberComparison comparison)
+        : this(
+            (OneOf<
+                EachNumberComparison,
+                EachStringComparison,
+                EachDateComparison,
+                EachDateTimeComparison,
+                EachTimeComparison
+            >)
+                comparison
+        )
+    { }
+
+    public EachComparison(EachStringComparison comparison)
+        : this(
+            (OneOf<
+                EachNumberComparison,
+                EachStringComparison,
+                EachDateComparison,
+                EachDateTimeComparison,
+                EachTimeComparison
+            >)
+                comparison
+        )
+    { }
+
+    public EachComparison(EachDateComparison comparison)
+        : this(
+            (OneOf<
+                EachNumberComparison,
+                EachStringComparison,
+                EachDateComparison,
+                EachDateTimeComparison,
+                EachTimeComparison
+            >)
+                comparison
+        )
+    { }
+
+    public EachComparison(EachDateTimeComparison comparison)
+        : this(
+            (OneOf<
+                EachNumberComparison,
+                EachStringComparison,
+                EachDateComparison,
+                EachDateTimeComparison,
+                EachTimeComparison
+            >)
+                comparison
+        )
+    { }
+
+    public EachComparison(EachTimeComparison comparison)
+        : this(
+            (OneOf<
+                EachNumberComparison,
+                EachStringComparison,
+                EachDateComparison,
+                EachDateTimeComparison,
+                EachTimeComparison
+            >)
+                comparison
+        )
+    { }
+
+    private EachComparison(
+        OneOf<
+            EachNumberComparison,
+            EachStringComparison,
+            EachDateComparison,
+            EachDateTimeComparison,
+            EachTimeComparison
+        > input
+    )
+        : base(input) { }
+}

--- a/src/PureQL.CSharp.Model/EachComparisons/EachComparisonOperator.cs
+++ b/src/PureQL.CSharp.Model/EachComparisons/EachComparisonOperator.cs
@@ -1,0 +1,9 @@
+namespace PureQL.CSharp.Model.EachComparisons;
+
+public enum EachComparisonOperator
+{
+    EachGreaterThan,
+    EachGreaterThanOrEqual,
+    EachLessThan,
+    EachLessThanOrEqual,
+}

--- a/src/PureQL.CSharp.Model/EachComparisons/EachDateComparison.cs
+++ b/src/PureQL.CSharp.Model/EachComparisons/EachDateComparison.cs
@@ -1,0 +1,25 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachComparisons;
+
+public sealed record EachDateComparison
+{
+    public EachDateComparison(
+        EachComparisonOperator @operator,
+        DateArrayReturning left,
+        OneOf<DateReturning, DateArrayReturning> right
+    )
+    {
+        Operator = @operator;
+        Left = left;
+        Right = right;
+    }
+
+    public EachComparisonOperator Operator { get; }
+
+    public DateArrayReturning Left { get; }
+
+    public OneOf<DateReturning, DateArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachComparisons/EachDateTimeComparison.cs
+++ b/src/PureQL.CSharp.Model/EachComparisons/EachDateTimeComparison.cs
@@ -1,0 +1,25 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachComparisons;
+
+public sealed record EachDateTimeComparison
+{
+    public EachDateTimeComparison(
+        EachComparisonOperator @operator,
+        DateTimeArrayReturning left,
+        OneOf<DateTimeReturning, DateTimeArrayReturning> right
+    )
+    {
+        Operator = @operator;
+        Left = left;
+        Right = right;
+    }
+
+    public EachComparisonOperator Operator { get; }
+
+    public DateTimeArrayReturning Left { get; }
+
+    public OneOf<DateTimeReturning, DateTimeArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachComparisons/EachNumberComparison.cs
+++ b/src/PureQL.CSharp.Model/EachComparisons/EachNumberComparison.cs
@@ -1,0 +1,25 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachComparisons;
+
+public sealed record EachNumberComparison
+{
+    public EachNumberComparison(
+        EachComparisonOperator @operator,
+        NumberArrayReturning left,
+        OneOf<NumberReturning, NumberArrayReturning> right
+    )
+    {
+        Operator = @operator;
+        Left = left;
+        Right = right;
+    }
+
+    public EachComparisonOperator Operator { get; }
+
+    public NumberArrayReturning Left { get; }
+
+    public OneOf<NumberReturning, NumberArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachComparisons/EachStringComparison.cs
+++ b/src/PureQL.CSharp.Model/EachComparisons/EachStringComparison.cs
@@ -1,0 +1,25 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachComparisons;
+
+public sealed record EachStringComparison
+{
+    public EachStringComparison(
+        EachComparisonOperator @operator,
+        StringArrayReturning left,
+        OneOf<StringReturning, StringArrayReturning> right
+    )
+    {
+        Operator = @operator;
+        Left = left;
+        Right = right;
+    }
+
+    public EachComparisonOperator Operator { get; }
+
+    public StringArrayReturning Left { get; }
+
+    public OneOf<StringReturning, StringArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachComparisons/EachTimeComparison.cs
+++ b/src/PureQL.CSharp.Model/EachComparisons/EachTimeComparison.cs
@@ -1,0 +1,25 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachComparisons;
+
+public sealed record EachTimeComparison
+{
+    public EachTimeComparison(
+        EachComparisonOperator @operator,
+        TimeArrayReturning left,
+        OneOf<TimeReturning, TimeArrayReturning> right
+    )
+    {
+        Operator = @operator;
+        Left = left;
+        Right = right;
+    }
+
+    public EachComparisonOperator Operator { get; }
+
+    public TimeArrayReturning Left { get; }
+
+    public OneOf<TimeReturning, TimeArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachDateArithmetics/EachDateAddDays.cs
+++ b/src/PureQL.CSharp.Model/EachDateArithmetics/EachDateAddDays.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachDateArithmetics;
+
+public sealed record EachDateAddDays
+{
+    public EachDateAddDays(
+        OneOf<DateReturning, DateArrayReturning> left,
+        OneOf<NumberReturning, NumberArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public OneOf<DateReturning, DateArrayReturning> Left { get; }
+
+    public OneOf<NumberReturning, NumberArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachDateArithmetics/EachDateDiffDays.cs
+++ b/src/PureQL.CSharp.Model/EachDateArithmetics/EachDateDiffDays.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachDateArithmetics;
+
+public sealed record EachDateDiffDays
+{
+    public EachDateDiffDays(
+        OneOf<DateReturning, DateArrayReturning> left,
+        OneOf<DateReturning, DateArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public OneOf<DateReturning, DateArrayReturning> Left { get; }
+
+    public OneOf<DateReturning, DateArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachDateTimeArithmetics/EachDateTimeAddSeconds.cs
+++ b/src/PureQL.CSharp.Model/EachDateTimeArithmetics/EachDateTimeAddSeconds.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachDateTimeArithmetics;
+
+public sealed record EachDateTimeAddSeconds
+{
+    public EachDateTimeAddSeconds(
+        OneOf<DateTimeReturning, DateTimeArrayReturning> left,
+        OneOf<NumberReturning, NumberArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public OneOf<DateTimeReturning, DateTimeArrayReturning> Left { get; }
+
+    public OneOf<NumberReturning, NumberArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachDateTimeArithmetics/EachDateTimeDiffSeconds.cs
+++ b/src/PureQL.CSharp.Model/EachDateTimeArithmetics/EachDateTimeDiffSeconds.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachDateTimeArithmetics;
+
+public sealed record EachDateTimeDiffSeconds
+{
+    public EachDateTimeDiffSeconds(
+        OneOf<DateTimeReturning, DateTimeArrayReturning> left,
+        OneOf<DateTimeReturning, DateTimeArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public OneOf<DateTimeReturning, DateTimeArrayReturning> Left { get; }
+
+    public OneOf<DateTimeReturning, DateTimeArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachEqualities/EachBooleanEquality.cs
+++ b/src/PureQL.CSharp.Model/EachEqualities/EachBooleanEquality.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachEqualities;
+
+public sealed record EachBooleanEquality
+{
+    public EachBooleanEquality(
+        BooleanArrayReturning left,
+        OneOf<BooleanReturning, BooleanArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public BooleanArrayReturning Left { get; }
+
+    public OneOf<BooleanReturning, BooleanArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachEqualities/EachDateEquality.cs
+++ b/src/PureQL.CSharp.Model/EachEqualities/EachDateEquality.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachEqualities;
+
+public sealed record EachDateEquality
+{
+    public EachDateEquality(
+        DateArrayReturning left,
+        OneOf<DateReturning, DateArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public DateArrayReturning Left { get; }
+
+    public OneOf<DateReturning, DateArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachEqualities/EachDateTimeEquality.cs
+++ b/src/PureQL.CSharp.Model/EachEqualities/EachDateTimeEquality.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachEqualities;
+
+public sealed record EachDateTimeEquality
+{
+    public EachDateTimeEquality(
+        DateTimeArrayReturning left,
+        OneOf<DateTimeReturning, DateTimeArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public DateTimeArrayReturning Left { get; }
+
+    public OneOf<DateTimeReturning, DateTimeArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachEqualities/EachEquality.cs
+++ b/src/PureQL.CSharp.Model/EachEqualities/EachEquality.cs
@@ -1,0 +1,133 @@
+using OneOf;
+
+namespace PureQL.CSharp.Model.EachEqualities;
+
+public sealed class EachEquality
+    : OneOfBase<
+        EachBooleanEquality,
+        EachNumberEquality,
+        EachStringEquality,
+        EachDateEquality,
+        EachTimeEquality,
+        EachDateTimeEquality,
+        EachUuidEquality
+    >
+{
+    public EachEquality(EachBooleanEquality equality)
+        : this(
+            (OneOf<
+                EachBooleanEquality,
+                EachNumberEquality,
+                EachStringEquality,
+                EachDateEquality,
+                EachTimeEquality,
+                EachDateTimeEquality,
+                EachUuidEquality
+            >)
+                equality
+        )
+    { }
+
+    public EachEquality(EachNumberEquality equality)
+        : this(
+            (OneOf<
+                EachBooleanEquality,
+                EachNumberEquality,
+                EachStringEquality,
+                EachDateEquality,
+                EachTimeEquality,
+                EachDateTimeEquality,
+                EachUuidEquality
+            >)
+                equality
+        )
+    { }
+
+    public EachEquality(EachStringEquality equality)
+        : this(
+            (OneOf<
+                EachBooleanEquality,
+                EachNumberEquality,
+                EachStringEquality,
+                EachDateEquality,
+                EachTimeEquality,
+                EachDateTimeEquality,
+                EachUuidEquality
+            >)
+                equality
+        )
+    { }
+
+    public EachEquality(EachDateEquality equality)
+        : this(
+            (OneOf<
+                EachBooleanEquality,
+                EachNumberEquality,
+                EachStringEquality,
+                EachDateEquality,
+                EachTimeEquality,
+                EachDateTimeEquality,
+                EachUuidEquality
+            >)
+                equality
+        )
+    { }
+
+    public EachEquality(EachTimeEquality equality)
+        : this(
+            (OneOf<
+                EachBooleanEquality,
+                EachNumberEquality,
+                EachStringEquality,
+                EachDateEquality,
+                EachTimeEquality,
+                EachDateTimeEquality,
+                EachUuidEquality
+            >)
+                equality
+        )
+    { }
+
+    public EachEquality(EachDateTimeEquality equality)
+        : this(
+            (OneOf<
+                EachBooleanEquality,
+                EachNumberEquality,
+                EachStringEquality,
+                EachDateEquality,
+                EachTimeEquality,
+                EachDateTimeEquality,
+                EachUuidEquality
+            >)
+                equality
+        )
+    { }
+
+    public EachEquality(EachUuidEquality equality)
+        : this(
+            (OneOf<
+                EachBooleanEquality,
+                EachNumberEquality,
+                EachStringEquality,
+                EachDateEquality,
+                EachTimeEquality,
+                EachDateTimeEquality,
+                EachUuidEquality
+            >)
+                equality
+        )
+    { }
+
+    private EachEquality(
+        OneOf<
+            EachBooleanEquality,
+            EachNumberEquality,
+            EachStringEquality,
+            EachDateEquality,
+            EachTimeEquality,
+            EachDateTimeEquality,
+            EachUuidEquality
+        > input
+    )
+        : base(input) { }
+}

--- a/src/PureQL.CSharp.Model/EachEqualities/EachNumberEquality.cs
+++ b/src/PureQL.CSharp.Model/EachEqualities/EachNumberEquality.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachEqualities;
+
+public sealed record EachNumberEquality
+{
+    public EachNumberEquality(
+        NumberArrayReturning left,
+        OneOf<NumberReturning, NumberArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public NumberArrayReturning Left { get; }
+
+    public OneOf<NumberReturning, NumberArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachEqualities/EachStringEquality.cs
+++ b/src/PureQL.CSharp.Model/EachEqualities/EachStringEquality.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachEqualities;
+
+public sealed record EachStringEquality
+{
+    public EachStringEquality(
+        StringArrayReturning left,
+        OneOf<StringReturning, StringArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public StringArrayReturning Left { get; }
+
+    public OneOf<StringReturning, StringArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachEqualities/EachTimeEquality.cs
+++ b/src/PureQL.CSharp.Model/EachEqualities/EachTimeEquality.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachEqualities;
+
+public sealed record EachTimeEquality
+{
+    public EachTimeEquality(
+        TimeArrayReturning left,
+        OneOf<TimeReturning, TimeArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public TimeArrayReturning Left { get; }
+
+    public OneOf<TimeReturning, TimeArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachEqualities/EachUuidEquality.cs
+++ b/src/PureQL.CSharp.Model/EachEqualities/EachUuidEquality.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachEqualities;
+
+public sealed record EachUuidEquality
+{
+    public EachUuidEquality(
+        UuidArrayReturning left,
+        OneOf<UuidReturning, UuidArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public UuidArrayReturning Left { get; }
+
+    public OneOf<UuidReturning, UuidArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachTimeArithmetics/EachTimeAddSeconds.cs
+++ b/src/PureQL.CSharp.Model/EachTimeArithmetics/EachTimeAddSeconds.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachTimeArithmetics;
+
+public sealed record EachTimeAddSeconds
+{
+    public EachTimeAddSeconds(
+        OneOf<TimeReturning, TimeArrayReturning> left,
+        OneOf<NumberReturning, NumberArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public OneOf<TimeReturning, TimeArrayReturning> Left { get; }
+
+    public OneOf<NumberReturning, NumberArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/EachTimeArithmetics/EachTimeDiffSeconds.cs
+++ b/src/PureQL.CSharp.Model/EachTimeArithmetics/EachTimeDiffSeconds.cs
@@ -1,0 +1,21 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Returnings;
+
+namespace PureQL.CSharp.Model.EachTimeArithmetics;
+
+public sealed record EachTimeDiffSeconds
+{
+    public EachTimeDiffSeconds(
+        OneOf<TimeReturning, TimeArrayReturning> left,
+        OneOf<TimeReturning, TimeArrayReturning> right
+    )
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public OneOf<TimeReturning, TimeArrayReturning> Left { get; }
+
+    public OneOf<TimeReturning, TimeArrayReturning> Right { get; }
+}

--- a/src/PureQL.CSharp.Model/Fields/Field.cs
+++ b/src/PureQL.CSharp.Model/Fields/Field.cs
@@ -7,6 +7,7 @@ public sealed class Field
         BooleanField,
         DateField,
         DateTimeField,
+        NullField,
         NumberField,
         TimeField,
         UuidField,
@@ -19,6 +20,7 @@ public sealed class Field
                 BooleanField,
                 DateField,
                 DateTimeField,
+                NullField,
                 NumberField,
                 TimeField,
                 UuidField,
@@ -34,6 +36,7 @@ public sealed class Field
                 BooleanField,
                 DateField,
                 DateTimeField,
+                NullField,
                 NumberField,
                 TimeField,
                 UuidField,
@@ -49,6 +52,23 @@ public sealed class Field
                 BooleanField,
                 DateField,
                 DateTimeField,
+                NullField,
+                NumberField,
+                TimeField,
+                UuidField,
+                StringField
+            >)
+                field
+        )
+    { }
+
+    public Field(NullField field)
+        : this(
+            (OneOf<
+                BooleanField,
+                DateField,
+                DateTimeField,
+                NullField,
                 NumberField,
                 TimeField,
                 UuidField,
@@ -64,6 +84,7 @@ public sealed class Field
                 BooleanField,
                 DateField,
                 DateTimeField,
+                NullField,
                 NumberField,
                 TimeField,
                 UuidField,
@@ -79,6 +100,7 @@ public sealed class Field
                 BooleanField,
                 DateField,
                 DateTimeField,
+                NullField,
                 NumberField,
                 TimeField,
                 UuidField,
@@ -94,6 +116,7 @@ public sealed class Field
                 BooleanField,
                 DateField,
                 DateTimeField,
+                NullField,
                 NumberField,
                 TimeField,
                 UuidField,
@@ -109,6 +132,7 @@ public sealed class Field
                 BooleanField,
                 DateField,
                 DateTimeField,
+                NullField,
                 NumberField,
                 TimeField,
                 UuidField,
@@ -123,6 +147,7 @@ public sealed class Field
             BooleanField,
             DateField,
             DateTimeField,
+            NullField,
             NumberField,
             TimeField,
             UuidField,

--- a/src/PureQL.CSharp.Model/Fields/NullField.cs
+++ b/src/PureQL.CSharp.Model/Fields/NullField.cs
@@ -1,0 +1,19 @@
+using PureQL.CSharp.Model.ArrayTypes;
+using PureQL.CSharp.Model.Types;
+
+namespace PureQL.CSharp.Model.Fields;
+
+public sealed record NullField : IField
+{
+    public NullField(string entity, string field)
+    {
+        Entity = entity;
+        Field = field;
+    }
+
+    public string Entity { get; }
+
+    public string Field { get; }
+
+    public IType Type => new NullArrayType();
+}

--- a/src/PureQL.CSharp.Model/FromExpression.cs
+++ b/src/PureQL.CSharp.Model/FromExpression.cs
@@ -2,7 +2,7 @@ namespace PureQL.CSharp.Model;
 
 public sealed record FromExpression
 {
-    public FromExpression(string entity, string alias)
+    public FromExpression(string entity, string? alias = null)
     {
         Entity = entity;
         Alias = alias;
@@ -10,5 +10,5 @@ public sealed record FromExpression
 
     public string Entity { get; }
 
-    public string Alias { get; }
+    public string? Alias { get; }
 }

--- a/src/PureQL.CSharp.Model/Join.cs
+++ b/src/PureQL.CSharp.Model/Join.cs
@@ -12,7 +12,11 @@ public sealed record Join
     public Join(JoinType type, string entity, BooleanArrayReturning on)
         : this(type, entity, (OneOf<BooleanReturning, BooleanArrayReturning>)on) { }
 
-    private Join(JoinType type, string entity, OneOf<BooleanReturning, BooleanArrayReturning> on)
+    private Join(
+        JoinType type,
+        string entity,
+        OneOf<BooleanReturning, BooleanArrayReturning> on
+    )
     {
         Type = type;
         Entity = entity;

--- a/src/PureQL.CSharp.Model/Join.cs
+++ b/src/PureQL.CSharp.Model/Join.cs
@@ -1,3 +1,5 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
 using PureQL.CSharp.Model.Returnings;
 
 namespace PureQL.CSharp.Model;
@@ -5,6 +7,12 @@ namespace PureQL.CSharp.Model;
 public sealed record Join
 {
     public Join(JoinType type, string entity, BooleanReturning on)
+        : this(type, entity, (OneOf<BooleanReturning, BooleanArrayReturning>)on) { }
+
+    public Join(JoinType type, string entity, BooleanArrayReturning on)
+        : this(type, entity, (OneOf<BooleanReturning, BooleanArrayReturning>)on) { }
+
+    private Join(JoinType type, string entity, OneOf<BooleanReturning, BooleanArrayReturning> on)
     {
         Type = type;
         Entity = entity;
@@ -15,5 +23,5 @@ public sealed record Join
 
     public string Entity { get; }
 
-    public BooleanReturning On { get; }
+    public OneOf<BooleanReturning, BooleanArrayReturning> On { get; }
 }

--- a/src/PureQL.CSharp.Model/OrderByItem.cs
+++ b/src/PureQL.CSharp.Model/OrderByItem.cs
@@ -1,0 +1,16 @@
+using PureQL.CSharp.Model.Fields;
+
+namespace PureQL.CSharp.Model;
+
+public sealed record OrderByItem
+{
+    public OrderByItem(Field field, SortDirection direction = SortDirection.Asc)
+    {
+        Field = field;
+        Direction = direction;
+    }
+
+    public Field Field { get; }
+
+    public SortDirection Direction { get; }
+}

--- a/src/PureQL.CSharp.Model/Query.cs
+++ b/src/PureQL.CSharp.Model/Query.cs
@@ -1,3 +1,5 @@
+using OneOf;
+using PureQL.CSharp.Model.ArrayReturnings;
 using PureQL.CSharp.Model.Fields;
 using PureQL.CSharp.Model.Returnings;
 
@@ -11,7 +13,7 @@ public sealed record Query
     public Query(
         FromExpression from,
         IEnumerable<SelectExpression> selectExpressions,
-        BooleanReturning? where,
+        OneOf<BooleanReturning, BooleanArrayReturning>? where,
         IEnumerable<Join>? join,
         IEnumerable<Field>? groupBy,
         BooleanReturning? having,
@@ -33,7 +35,7 @@ public sealed record Query
 
     public IEnumerable<SelectExpression> SelectExpressions { get; }
 
-    public BooleanReturning? Where { get; }
+    public OneOf<BooleanReturning, BooleanArrayReturning>? Where { get; }
 
     public IEnumerable<Join>? Join { get; }
 

--- a/src/PureQL.CSharp.Model/Query.cs
+++ b/src/PureQL.CSharp.Model/Query.cs
@@ -8,7 +8,7 @@ namespace PureQL.CSharp.Model;
 public sealed record Query
 {
     public Query(FromExpression from, IEnumerable<SelectExpression> select)
-        : this(from, select, null, null, null, null, null, null) { }
+        : this(from, select, null, null, null, null, null, null, false) { }
 
     public Query(
         FromExpression from,
@@ -18,7 +18,8 @@ public sealed record Query
         IEnumerable<Field>? groupBy,
         BooleanReturning? having,
         IEnumerable<OrderByItem>? orderBy,
-        Pagination? pagination
+        Pagination? pagination,
+        bool distinct = false
     )
     {
         From = from;
@@ -29,6 +30,7 @@ public sealed record Query
         Having = having;
         OrderBy = orderBy;
         Pagination = pagination;
+        Distinct = distinct;
     }
 
     public FromExpression From { get; }
@@ -46,4 +48,6 @@ public sealed record Query
     public IEnumerable<OrderByItem>? OrderBy { get; }
 
     public Pagination? Pagination { get; }
+
+    public bool Distinct { get; }
 }

--- a/src/PureQL.CSharp.Model/Query.cs
+++ b/src/PureQL.CSharp.Model/Query.cs
@@ -17,7 +17,7 @@ public sealed record Query
         IEnumerable<Join>? join,
         IEnumerable<Field>? groupBy,
         BooleanReturning? having,
-        IEnumerable<Field>? orderBy,
+        IEnumerable<OrderByItem>? orderBy,
         Pagination? pagination
     )
     {
@@ -43,7 +43,7 @@ public sealed record Query
 
     public BooleanReturning? Having { get; }
 
-    public IEnumerable<Field>? OrderBy { get; }
+    public IEnumerable<OrderByItem>? OrderBy { get; }
 
     public Pagination? Pagination { get; }
 }

--- a/src/PureQL.CSharp.Model/Returnings/DateReturning.cs
+++ b/src/PureQL.CSharp.Model/Returnings/DateReturning.cs
@@ -1,17 +1,21 @@
 using OneOf;
+using PureQL.CSharp.Model.Aggregates.Date;
 using PureQL.CSharp.Model.Parameters;
 using PureQL.CSharp.Model.Scalars;
 
 namespace PureQL.CSharp.Model.Returnings;
 
-public sealed class DateReturning : OneOfBase<DateParameter, DateScalar>
+public sealed class DateReturning : OneOfBase<DateParameter, DateScalar, DateAggregate>
 {
     public DateReturning(DateParameter parameter)
-        : this((OneOf<DateParameter, DateScalar>)parameter) { }
+        : this((OneOf<DateParameter, DateScalar, DateAggregate>)parameter) { }
 
     public DateReturning(DateScalar scalar)
-        : this((OneOf<DateParameter, DateScalar>)scalar) { }
+        : this((OneOf<DateParameter, DateScalar, DateAggregate>)scalar) { }
 
-    private DateReturning(OneOf<DateParameter, DateScalar> input)
+    public DateReturning(DateAggregate aggregate)
+        : this((OneOf<DateParameter, DateScalar, DateAggregate>)aggregate) { }
+
+    private DateReturning(OneOf<DateParameter, DateScalar, DateAggregate> input)
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/Returnings/DateTimeReturning.cs
+++ b/src/PureQL.CSharp.Model/Returnings/DateTimeReturning.cs
@@ -1,17 +1,22 @@
 using OneOf;
+using PureQL.CSharp.Model.Aggregates.DateTime;
 using PureQL.CSharp.Model.Parameters;
 using PureQL.CSharp.Model.Scalars;
 
 namespace PureQL.CSharp.Model.Returnings;
 
-public sealed class DateTimeReturning : OneOfBase<DateTimeParameter, DateTimeScalar>
+public sealed class DateTimeReturning
+    : OneOfBase<DateTimeParameter, DateTimeScalar, DateTimeAggregate>
 {
     public DateTimeReturning(DateTimeParameter parameter)
-        : this((OneOf<DateTimeParameter, DateTimeScalar>)parameter) { }
+        : this((OneOf<DateTimeParameter, DateTimeScalar, DateTimeAggregate>)parameter) { }
 
     public DateTimeReturning(DateTimeScalar scalar)
-        : this((OneOf<DateTimeParameter, DateTimeScalar>)scalar) { }
+        : this((OneOf<DateTimeParameter, DateTimeScalar, DateTimeAggregate>)scalar) { }
 
-    private DateTimeReturning(OneOf<DateTimeParameter, DateTimeScalar> input)
+    public DateTimeReturning(DateTimeAggregate aggregate)
+        : this((OneOf<DateTimeParameter, DateTimeScalar, DateTimeAggregate>)aggregate) { }
+
+    private DateTimeReturning(OneOf<DateTimeParameter, DateTimeScalar, DateTimeAggregate> input)
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/Returnings/DateTimeReturning.cs
+++ b/src/PureQL.CSharp.Model/Returnings/DateTimeReturning.cs
@@ -17,6 +17,8 @@ public sealed class DateTimeReturning
     public DateTimeReturning(DateTimeAggregate aggregate)
         : this((OneOf<DateTimeParameter, DateTimeScalar, DateTimeAggregate>)aggregate) { }
 
-    private DateTimeReturning(OneOf<DateTimeParameter, DateTimeScalar, DateTimeAggregate> input)
+    private DateTimeReturning(
+        OneOf<DateTimeParameter, DateTimeScalar, DateTimeAggregate> input
+    )
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/Returnings/NumberReturning.cs
+++ b/src/PureQL.CSharp.Model/Returnings/NumberReturning.cs
@@ -11,20 +11,42 @@ public sealed class NumberReturning
     : OneOfBase<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>
 {
     public NumberReturning(NumberParameter parameter)
-        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)parameter) { }
+        : this(
+            (OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)
+                parameter
+        )
+    { }
 
     public NumberReturning(NumberScalar scalar)
-        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)scalar) { }
+        : this(
+            (OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)
+                scalar
+        )
+    { }
 
     public NumberReturning(Arithmetic arithmetic)
-        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)arithmetic) { }
+        : this(
+            (OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)
+                arithmetic
+        )
+    { }
 
     public NumberReturning(NumberAggregate aggregate)
-        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)aggregate) { }
+        : this(
+            (OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)
+                aggregate
+        )
+    { }
 
     public NumberReturning(Count count)
-        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)count) { }
+        : this(
+            (OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)
+                count
+        )
+    { }
 
-    private NumberReturning(OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count> input)
+    private NumberReturning(
+        OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count> input
+    )
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/Returnings/NumberReturning.cs
+++ b/src/PureQL.CSharp.Model/Returnings/NumberReturning.cs
@@ -1,17 +1,30 @@
 using OneOf;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.Arithmetics;
 using PureQL.CSharp.Model.Parameters;
 using PureQL.CSharp.Model.Scalars;
 
 namespace PureQL.CSharp.Model.Returnings;
 
-public sealed class NumberReturning : OneOfBase<NumberParameter, NumberScalar>
+public sealed class NumberReturning
+    : OneOfBase<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>
 {
     public NumberReturning(NumberParameter parameter)
-        : this((OneOf<NumberParameter, NumberScalar>)parameter) { }
+        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)parameter) { }
 
     public NumberReturning(NumberScalar scalar)
-        : this((OneOf<NumberParameter, NumberScalar>)scalar) { }
+        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)scalar) { }
 
-    private NumberReturning(OneOf<NumberParameter, NumberScalar> input)
+    public NumberReturning(Arithmetic arithmetic)
+        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)arithmetic) { }
+
+    public NumberReturning(NumberAggregate aggregate)
+        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)aggregate) { }
+
+    public NumberReturning(Count count)
+        : this((OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count>)count) { }
+
+    private NumberReturning(OneOf<NumberParameter, NumberScalar, Arithmetic, NumberAggregate, Count> input)
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/Returnings/StringReturning.cs
+++ b/src/PureQL.CSharp.Model/Returnings/StringReturning.cs
@@ -1,17 +1,21 @@
 using OneOf;
+using PureQL.CSharp.Model.Aggregates.String;
 using PureQL.CSharp.Model.Parameters;
 using PureQL.CSharp.Model.Scalars;
 
 namespace PureQL.CSharp.Model.Returnings;
 
-public sealed class StringReturning : OneOfBase<StringParameter, StringScalar>
+public sealed class StringReturning : OneOfBase<StringParameter, StringScalar, StringAggregate>
 {
     public StringReturning(StringParameter parameter)
-        : this((OneOf<StringParameter, StringScalar>)parameter) { }
+        : this((OneOf<StringParameter, StringScalar, StringAggregate>)parameter) { }
 
     public StringReturning(StringScalar scalar)
-        : this((OneOf<StringParameter, StringScalar>)scalar) { }
+        : this((OneOf<StringParameter, StringScalar, StringAggregate>)scalar) { }
 
-    private StringReturning(OneOf<StringParameter, StringScalar> input)
+    public StringReturning(StringAggregate aggregate)
+        : this((OneOf<StringParameter, StringScalar, StringAggregate>)aggregate) { }
+
+    private StringReturning(OneOf<StringParameter, StringScalar, StringAggregate> input)
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/Returnings/StringReturning.cs
+++ b/src/PureQL.CSharp.Model/Returnings/StringReturning.cs
@@ -5,7 +5,8 @@ using PureQL.CSharp.Model.Scalars;
 
 namespace PureQL.CSharp.Model.Returnings;
 
-public sealed class StringReturning : OneOfBase<StringParameter, StringScalar, StringAggregate>
+public sealed class StringReturning
+    : OneOfBase<StringParameter, StringScalar, StringAggregate>
 {
     public StringReturning(StringParameter parameter)
         : this((OneOf<StringParameter, StringScalar, StringAggregate>)parameter) { }

--- a/src/PureQL.CSharp.Model/Returnings/TimeReturning.cs
+++ b/src/PureQL.CSharp.Model/Returnings/TimeReturning.cs
@@ -1,17 +1,21 @@
 using OneOf;
+using PureQL.CSharp.Model.Aggregates.Time;
 using PureQL.CSharp.Model.Parameters;
 using PureQL.CSharp.Model.Scalars;
 
 namespace PureQL.CSharp.Model.Returnings;
 
-public sealed class TimeReturning : OneOfBase<TimeParameter, TimeScalar>
+public sealed class TimeReturning : OneOfBase<TimeParameter, TimeScalar, TimeAggregate>
 {
     public TimeReturning(TimeParameter parameter)
-        : this((OneOf<TimeParameter, TimeScalar>)parameter) { }
+        : this((OneOf<TimeParameter, TimeScalar, TimeAggregate>)parameter) { }
 
     public TimeReturning(TimeScalar scalar)
-        : this((OneOf<TimeParameter, TimeScalar>)scalar) { }
+        : this((OneOf<TimeParameter, TimeScalar, TimeAggregate>)scalar) { }
 
-    private TimeReturning(OneOf<TimeParameter, TimeScalar> input)
+    public TimeReturning(TimeAggregate aggregate)
+        : this((OneOf<TimeParameter, TimeScalar, TimeAggregate>)aggregate) { }
+
+    private TimeReturning(OneOf<TimeParameter, TimeScalar, TimeAggregate> input)
         : base(input) { }
 }

--- a/src/PureQL.CSharp.Model/SortDirection.cs
+++ b/src/PureQL.CSharp.Model/SortDirection.cs
@@ -1,0 +1,7 @@
+namespace PureQL.CSharp.Model;
+
+public enum SortDirection
+{
+    Asc,
+    Desc,
+}

--- a/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
+++ b/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
@@ -3,7 +3,6 @@ using PureQL.CSharp.Model.Aggregates;
 using PureQL.CSharp.Model.Aggregates.Numeric;
 using PureQL.CSharp.Model.Arithmetics;
 using PureQL.CSharp.Model.ArrayReturnings;
-using PureQL.CSharp.Model.ArrayScalars;
 using PureQL.CSharp.Model.EachArithmetics;
 using PureQL.CSharp.Model.EachBooleanOperations;
 using PureQL.CSharp.Model.EachComparisons;
@@ -21,44 +20,74 @@ public sealed class PureQLTests
 {
     // ── helpers ──────────────────────────────────────────────────────────────
 
-    private static NumberField NumF(string entity, string field) => new(entity, field);
-    private static StringField StrF(string entity, string field) => new(entity, field);
-    private static DateField DateF(string entity, string field) => new(entity, field);
-    private static DateTimeField DtF(string entity, string field) => new(entity, field);
-    private static TimeField TimeF(string entity, string field) => new(entity, field);
-    private static UuidField UuidF(string entity, string field) => new(entity, field);
-    private static BooleanField BoolF(string entity, string field) => new(entity, field);
+    private static NumberField NumF(string entity, string field)
+    {
+        return new(entity, field);
+    }
+
+    private static StringField StrF(string entity, string field)
+    {
+        return new(entity, field);
+    }
+
+    private static DateField DateF(string entity, string field)
+    {
+        return new(entity, field);
+    }
+
+    private static DateTimeField DtF(string entity, string field)
+    {
+        return new(entity, field);
+    }
+
+    private static TimeField TimeF(string entity, string field)
+    {
+        return new(entity, field);
+    }
+
+    private static UuidField UuidF(string entity, string field)
+    {
+        return new(entity, field);
+    }
+
+    private static BooleanField BoolF(string entity, string field)
+    {
+        return new(entity, field);
+    }
 
     // ── basic query construction ──────────────────────────────────────────────
 
     [Fact]
-    public void SimpleSelect_Constructs()
+    public void SimpleSelectConstructs()
     {
-        var from = new FromExpression("orders", "o");
-        var select = new[]
+        FromExpression from = new FromExpression("orders", "o");
+        SelectExpression[] select = new[]
         {
             new SelectExpression(
-                new SingleValueReturning(
-                    new NumberReturning(new NumberScalar(1))
-                ),
+                new SingleValueReturning(new NumberReturning(new NumberScalar(1))),
                 "one"
             ),
         };
 
-        var query = new Query(from, select);
+        Query query = new Query(from, select);
 
         Assert.Equal("orders", query.From.Entity);
-        Assert.Single(query.SelectExpressions);
+        _ = Assert.Single(query.SelectExpressions);
     }
 
     [Fact]
-    public void Query_WithPagination_Constructs()
+    public void QueryWithPaginationConstructs()
     {
-        var from = new FromExpression("users", "u");
-        var select = new[] { new SelectExpression(new ArrayReturning(new NumberArrayReturning(NumF("users", "id")))) };
-        var pagination = new Pagination(0, 10);
+        FromExpression from = new FromExpression("users", "u");
+        SelectExpression[] select = new[]
+        {
+            new SelectExpression(
+                new ArrayReturning(new NumberArrayReturning(NumF("users", "id")))
+            ),
+        };
+        Pagination pagination = new Pagination(0, 10);
 
-        var query = new Query(from, select, null, null, null, null, null, pagination);
+        Query query = new Query(from, select, null, null, null, null, null, pagination);
 
         Assert.NotNull(query.Pagination);
         Assert.Equal(0, query.Pagination!.Skip);
@@ -68,128 +97,157 @@ public sealed class PureQLTests
     // ── OrderBy with direction ────────────────────────────────────────────────
 
     [Fact]
-    public void OrderByItem_DefaultsToAsc()
+    public void OrderByItemDefaultsToAsc()
     {
-        var item = new OrderByItem(new Field(NumF("orders", "amount")));
+        OrderByItem item = new OrderByItem(new Field(NumF("orders", "amount")));
 
         Assert.Equal(SortDirection.Asc, item.Direction);
     }
 
     [Fact]
-    public void OrderByItem_ExplicitDesc()
+    public void OrderByItemExplicitDesc()
     {
-        var item = new OrderByItem(new Field(NumF("orders", "amount")), SortDirection.Desc);
+        OrderByItem item = new OrderByItem(
+            new Field(NumF("orders", "amount")),
+            SortDirection.Desc
+        );
 
         Assert.Equal(SortDirection.Desc, item.Direction);
     }
 
     [Fact]
-    public void Query_WithOrderByItem_Constructs()
+    public void QueryWithOrderByItemConstructs()
     {
-        var from = new FromExpression("orders", "o");
-        var select = new[] { new SelectExpression(new ArrayReturning(new NumberArrayReturning(NumF("orders", "amount")))) };
-        var orderBy = new[]
+        FromExpression from = new FromExpression("orders", "o");
+        SelectExpression[] select = new[]
+        {
+            new SelectExpression(
+                new ArrayReturning(new NumberArrayReturning(NumF("orders", "amount")))
+            ),
+        };
+        OrderByItem[] orderBy = new[]
         {
             new OrderByItem(new Field(NumF("orders", "amount")), SortDirection.Desc),
         };
 
-        var query = new Query(from, select, null, null, null, null, orderBy, null);
+        Query query = new Query(from, select, null, null, null, null, orderBy, null);
 
-        Assert.Single(query.OrderBy!);
+        _ = Assert.Single(query.OrderBy!);
         Assert.Equal(SortDirection.Desc, query.OrderBy!.First().Direction);
     }
 
     // ── each* equality ────────────────────────────────────────────────────────
 
     [Fact]
-    public void EachNumberEquality_WithScalarRight_Constructs()
+    public void EachNumberEqualityWithScalarRightConstructs()
     {
-        var left = new NumberArrayReturning(NumF("orders", "status_code"));
-        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
-            new NumberReturning(new NumberScalar(200))
+        NumberArrayReturning left = new NumberArrayReturning(
+            NumF("orders", "status_code")
         );
+        OneOf<NumberReturning, NumberArrayReturning> right = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT0(new NumberReturning(new NumberScalar(200)));
 
-        var equality = new EachNumberEquality(left, right);
-        var boolArray = new BooleanArrayReturning(new EachEquality(equality));
+        EachNumberEquality equality = new EachNumberEquality(left, right);
+        BooleanArrayReturning boolArray = new BooleanArrayReturning(
+            new EachEquality(equality)
+        );
 
         Assert.True(boolArray.IsT4);
     }
 
     [Fact]
-    public void EachStringEquality_WithScalarRight_Constructs()
+    public void EachStringEqualityWithScalarRightConstructs()
     {
-        var left = new StringArrayReturning(StrF("users", "status"));
-        var right = OneOf<StringReturning, StringArrayReturning>.FromT0(
-            new StringReturning(new StringScalar("active"))
-        );
+        StringArrayReturning left = new StringArrayReturning(StrF("users", "status"));
+        OneOf<StringReturning, StringArrayReturning> right = OneOf<
+            StringReturning,
+            StringArrayReturning
+        >.FromT0(new StringReturning(new StringScalar("active")));
 
-        var equality = new EachStringEquality(left, right);
-        var boolArray = new BooleanArrayReturning(new EachEquality(equality));
+        EachStringEquality equality = new EachStringEquality(left, right);
+        BooleanArrayReturning boolArray = new BooleanArrayReturning(
+            new EachEquality(equality)
+        );
 
         Assert.True(boolArray.IsT4);
     }
 
     [Fact]
-    public void EachUuidEquality_FieldToField_Constructs()
+    public void EachUuidEqualityFieldToFieldConstructs()
     {
-        var left = new UuidArrayReturning(UuidF("users", "id"));
-        var right = OneOf<UuidReturning, UuidArrayReturning>.FromT1(
-            new UuidArrayReturning(UuidF("orders", "user_id"))
-        );
+        UuidArrayReturning left = new UuidArrayReturning(UuidF("users", "id"));
+        OneOf<UuidReturning, UuidArrayReturning> right = OneOf<
+            UuidReturning,
+            UuidArrayReturning
+        >.FromT1(new UuidArrayReturning(UuidF("orders", "user_id")));
 
-        var equality = new EachUuidEquality(left, right);
+        EachUuidEquality equality = new EachUuidEquality(left, right);
 
         Assert.NotNull(equality);
     }
 
     [Fact]
-    public void EachDateEquality_Constructs()
+    public void EachDateEqualityConstructs()
     {
-        var left = new DateArrayReturning(DateF("orders", "order_date"));
-        var right = OneOf<DateReturning, DateArrayReturning>.FromT0(
-            new DateReturning(new DateScalar(new DateOnly(2024, 1, 1)))
-        );
+        DateArrayReturning left = new DateArrayReturning(DateF("orders", "order_date"));
+        OneOf<DateReturning, DateArrayReturning> right = OneOf<
+            DateReturning,
+            DateArrayReturning
+        >.FromT0(new DateReturning(new DateScalar(new DateOnly(2024, 1, 1))));
 
-        var equality = new EachDateEquality(left, right);
+        EachDateEquality equality = new EachDateEquality(left, right);
 
         Assert.NotNull(equality);
     }
 
     [Fact]
-    public void EachBooleanEquality_Constructs()
+    public void EachBooleanEqualityConstructs()
     {
-        var left = new BooleanArrayReturning(BoolF("users", "is_active"));
-        var right = OneOf<BooleanReturning, BooleanArrayReturning>.FromT0(
-            new BooleanReturning(new BooleanScalar(true))
+        BooleanArrayReturning left = new BooleanArrayReturning(
+            BoolF("users", "is_active")
         );
+        OneOf<BooleanReturning, BooleanArrayReturning> right = OneOf<
+            BooleanReturning,
+            BooleanArrayReturning
+        >.FromT0(new BooleanReturning(new BooleanScalar(true)));
 
-        var equality = new EachBooleanEquality(left, right);
+        EachBooleanEquality equality = new EachBooleanEquality(left, right);
 
         Assert.NotNull(equality);
     }
 
     [Fact]
-    public void EachTimeEquality_Constructs()
+    public void EachTimeEqualityConstructs()
     {
-        var left = new TimeArrayReturning(TimeF("shifts", "start_time"));
-        var right = OneOf<TimeReturning, TimeArrayReturning>.FromT0(
-            new TimeReturning(new TimeScalar(new TimeOnly(8, 0, 0)))
-        );
+        TimeArrayReturning left = new TimeArrayReturning(TimeF("shifts", "start_time"));
+        OneOf<TimeReturning, TimeArrayReturning> right = OneOf<
+            TimeReturning,
+            TimeArrayReturning
+        >.FromT0(new TimeReturning(new TimeScalar(new TimeOnly(8, 0, 0))));
 
-        var equality = new EachTimeEquality(left, right);
+        EachTimeEquality equality = new EachTimeEquality(left, right);
 
         Assert.NotNull(equality);
     }
 
     [Fact]
-    public void EachDateTimeEquality_Constructs()
+    public void EachDateTimeEqualityConstructs()
     {
-        var left = new DateTimeArrayReturning(DtF("events", "starts_at"));
-        var right = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT0(
-            new DateTimeReturning(new DateTimeScalar(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)))
+        DateTimeArrayReturning left = new DateTimeArrayReturning(
+            DtF("events", "starts_at")
+        );
+        OneOf<DateTimeReturning, DateTimeArrayReturning> right = OneOf<
+            DateTimeReturning,
+            DateTimeArrayReturning
+        >.FromT0(
+            new DateTimeReturning(
+                new DateTimeScalar(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            )
         );
 
-        var equality = new EachDateTimeEquality(left, right);
+        EachDateTimeEquality equality = new EachDateTimeEquality(left, right);
 
         Assert.NotNull(equality);
     }
@@ -197,67 +255,102 @@ public sealed class PureQLTests
     // ── each* comparisons ─────────────────────────────────────────────────────
 
     [Fact]
-    public void EachNumberComparison_GreaterThan_Constructs()
+    public void EachNumberComparisonGreaterThanConstructs()
     {
-        var left = new NumberArrayReturning(NumF("order_items", "unit_price"));
-        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
-            new NumberReturning(new NumberScalar(100))
+        NumberArrayReturning left = new NumberArrayReturning(
+            NumF("order_items", "unit_price")
         );
+        OneOf<NumberReturning, NumberArrayReturning> right = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT0(new NumberReturning(new NumberScalar(100)));
 
-        var comparison = new EachNumberComparison(EachComparisonOperator.EachGreaterThan, left, right);
-        var boolArray = new BooleanArrayReturning(new EachComparison(comparison));
+        EachNumberComparison comparison = new EachNumberComparison(
+            EachComparisonOperator.EachGreaterThan,
+            left,
+            right
+        );
+        BooleanArrayReturning boolArray = new BooleanArrayReturning(
+            new EachComparison(comparison)
+        );
 
         Assert.True(boolArray.IsT3);
     }
 
     [Fact]
-    public void EachDateComparison_FieldToField_Constructs()
+    public void EachDateComparisonFieldToFieldConstructs()
     {
-        var left = new DateArrayReturning(DateF("orders", "shipped_at"));
-        var right = OneOf<DateReturning, DateArrayReturning>.FromT1(
-            new DateArrayReturning(DateF("orders", "expected_at"))
-        );
+        DateArrayReturning left = new DateArrayReturning(DateF("orders", "shipped_at"));
+        OneOf<DateReturning, DateArrayReturning> right = OneOf<
+            DateReturning,
+            DateArrayReturning
+        >.FromT1(new DateArrayReturning(DateF("orders", "expected_at")));
 
-        var comparison = new EachDateComparison(EachComparisonOperator.EachLessThan, left, right);
+        EachDateComparison comparison = new EachDateComparison(
+            EachComparisonOperator.EachLessThan,
+            left,
+            right
+        );
 
         Assert.Equal(EachComparisonOperator.EachLessThan, comparison.Operator);
     }
 
     [Fact]
-    public void EachStringComparison_Constructs()
+    public void EachStringComparisonConstructs()
     {
-        var left = new StringArrayReturning(StrF("products", "name"));
-        var right = OneOf<StringReturning, StringArrayReturning>.FromT0(
-            new StringReturning(new StringScalar("M"))
-        );
+        StringArrayReturning left = new StringArrayReturning(StrF("products", "name"));
+        OneOf<StringReturning, StringArrayReturning> right = OneOf<
+            StringReturning,
+            StringArrayReturning
+        >.FromT0(new StringReturning(new StringScalar("M")));
 
-        var comparison = new EachStringComparison(EachComparisonOperator.EachGreaterThanOrEqual, left, right);
+        EachStringComparison comparison = new EachStringComparison(
+            EachComparisonOperator.EachGreaterThanOrEqual,
+            left,
+            right
+        );
 
         Assert.NotNull(comparison);
     }
 
     [Fact]
-    public void EachTimeComparison_Constructs()
+    public void EachTimeComparisonConstructs()
     {
-        var left = new TimeArrayReturning(TimeF("shifts", "clock_out"));
-        var right = OneOf<TimeReturning, TimeArrayReturning>.FromT0(
-            new TimeReturning(new TimeScalar(new TimeOnly(17, 0, 0)))
-        );
+        TimeArrayReturning left = new TimeArrayReturning(TimeF("shifts", "clock_out"));
+        OneOf<TimeReturning, TimeArrayReturning> right = OneOf<
+            TimeReturning,
+            TimeArrayReturning
+        >.FromT0(new TimeReturning(new TimeScalar(new TimeOnly(17, 0, 0))));
 
-        var comparison = new EachTimeComparison(EachComparisonOperator.EachGreaterThan, left, right);
+        EachTimeComparison comparison = new EachTimeComparison(
+            EachComparisonOperator.EachGreaterThan,
+            left,
+            right
+        );
 
         Assert.NotNull(comparison);
     }
 
     [Fact]
-    public void EachDateTimeComparison_Constructs()
+    public void EachDateTimeComparisonConstructs()
     {
-        var left = new DateTimeArrayReturning(DtF("orders", "shipped_at"));
-        var right = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT0(
-            new DateTimeReturning(new DateTimeScalar(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)))
+        DateTimeArrayReturning left = new DateTimeArrayReturning(
+            DtF("orders", "shipped_at")
+        );
+        OneOf<DateTimeReturning, DateTimeArrayReturning> right = OneOf<
+            DateTimeReturning,
+            DateTimeArrayReturning
+        >.FromT0(
+            new DateTimeReturning(
+                new DateTimeScalar(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            )
         );
 
-        var comparison = new EachDateTimeComparison(EachComparisonOperator.EachGreaterThan, left, right);
+        EachDateTimeComparison comparison = new EachDateTimeComparison(
+            EachComparisonOperator.EachGreaterThan,
+            left,
+            right
+        );
 
         Assert.NotNull(comparison);
     }
@@ -265,9 +358,9 @@ public sealed class PureQLTests
     // ── each* boolean operations ──────────────────────────────────────────────
 
     [Fact]
-    public void EachAndOperator_ComposesMultiplePredicates()
+    public void EachAndOperatorComposesMultiplePredicates()
     {
-        var pred1 = new BooleanArrayReturning(
+        BooleanArrayReturning pred1 = new BooleanArrayReturning(
             new EachEquality(
                 new EachStringEquality(
                     new StringArrayReturning(StrF("users", "status")),
@@ -278,7 +371,7 @@ public sealed class PureQLTests
             )
         );
 
-        var pred2 = new BooleanArrayReturning(
+        BooleanArrayReturning pred2 = new BooleanArrayReturning(
             new EachComparison(
                 new EachNumberComparison(
                     EachComparisonOperator.EachGreaterThan,
@@ -290,28 +383,32 @@ public sealed class PureQLTests
             )
         );
 
-        var andOp = new EachAndOperator(new[] { pred1, pred2 });
-        var result = new BooleanArrayReturning(andOp);
+        EachAndOperator andOp = new EachAndOperator([pred1, pred2]);
+        BooleanArrayReturning result = new BooleanArrayReturning(andOp);
 
         Assert.True(result.IsT5);
     }
 
     [Fact]
-    public void EachOrOperator_Constructs()
+    public void EachOrOperatorConstructs()
     {
-        var pred1 = new BooleanArrayReturning(BoolF("users", "is_premium"));
-        var pred2 = new BooleanArrayReturning(BoolF("users", "is_admin"));
+        BooleanArrayReturning pred1 = new BooleanArrayReturning(
+            BoolF("users", "is_premium")
+        );
+        BooleanArrayReturning pred2 = new BooleanArrayReturning(
+            BoolF("users", "is_admin")
+        );
 
-        var orOp = new EachOrOperator(new[] { pred1, pred2 });
-        var result = new BooleanArrayReturning(orOp);
+        EachOrOperator orOp = new EachOrOperator([pred1, pred2]);
+        BooleanArrayReturning result = new BooleanArrayReturning(orOp);
 
         Assert.True(result.IsT6);
     }
 
     [Fact]
-    public void EachNotOperator_Constructs()
+    public void EachNotOperatorConstructs()
     {
-        var inner = new BooleanArrayReturning(
+        BooleanArrayReturning inner = new BooleanArrayReturning(
             new EachEquality(
                 new EachBooleanEquality(
                     new BooleanArrayReturning(BoolF("users", "is_deleted")),
@@ -322,8 +419,8 @@ public sealed class PureQLTests
             )
         );
 
-        var notOp = new EachNotOperator(inner);
-        var result = new BooleanArrayReturning(notOp);
+        EachNotOperator notOp = new EachNotOperator(inner);
+        BooleanArrayReturning result = new BooleanArrayReturning(notOp);
 
         Assert.True(result.IsT7);
     }
@@ -331,52 +428,79 @@ public sealed class PureQLTests
     // ── per-row arithmetic ────────────────────────────────────────────────────
 
     [Fact]
-    public void EachMultiply_FieldByScalar_ProducesNumericArrayReturning()
+    public void EachMultiplyFieldByScalarProducesNumericArrayReturning()
     {
-        var fieldArg = OneOf<NumberReturning, NumberArrayReturning>.FromT1(
-            new NumberArrayReturning(NumF("order_items", "unit_price"))
-        );
-        var scalarArg = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
-            new NumberReturning(new NumberScalar(1.05))
-        );
+        OneOf<NumberReturning, NumberArrayReturning> fieldArg = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT1(new NumberArrayReturning(NumF("order_items", "unit_price")));
+        OneOf<NumberReturning, NumberArrayReturning> scalarArg = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT0(new NumberReturning(new NumberScalar(1.05)));
 
-        var multiply = new EachMultiply(new[] { fieldArg, scalarArg });
-        var result = new NumberArrayReturning(new EachArithmetic(multiply));
+        EachMultiply multiply = new EachMultiply([fieldArg, scalarArg]);
+        NumberArrayReturning result = new NumberArrayReturning(
+            new EachArithmetic(multiply)
+        );
 
         Assert.True(result.IsT3);
     }
 
     [Fact]
-    public void EachAdd_ThreeOperands_Constructs()
+    public void EachAddThreeOperandsConstructs()
     {
-        var a = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "base_price")));
-        var b = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "tax")));
-        var c = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "shipping")));
+        OneOf<NumberReturning, NumberArrayReturning> a = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT1(new NumberArrayReturning(NumF("items", "base_price")));
+        OneOf<NumberReturning, NumberArrayReturning> b = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT1(new NumberArrayReturning(NumF("items", "tax")));
+        OneOf<NumberReturning, NumberArrayReturning> c = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT1(new NumberArrayReturning(NumF("items", "shipping")));
 
-        var add = new EachAdd(new[] { a, b, c });
+        EachAdd add = new EachAdd([a, b, c]);
 
         Assert.Equal(3, add.Values.Count());
     }
 
     [Fact]
-    public void EachSubtract_Constructs()
+    public void EachSubtractConstructs()
     {
-        var a = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "price")));
-        var b = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "discount")));
+        OneOf<NumberReturning, NumberArrayReturning> a = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT1(new NumberArrayReturning(NumF("items", "price")));
+        OneOf<NumberReturning, NumberArrayReturning> b = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT1(new NumberArrayReturning(NumF("items", "discount")));
 
-        var subtract = new EachSubtract(new[] { a, b });
-        var result = new NumberArrayReturning(new EachArithmetic(subtract));
+        EachSubtract subtract = new EachSubtract([a, b]);
+        NumberArrayReturning result = new NumberArrayReturning(
+            new EachArithmetic(subtract)
+        );
 
         Assert.True(result.IsT3);
     }
 
     [Fact]
-    public void EachDivide_Constructs()
+    public void EachDivideConstructs()
     {
-        var a = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "total")));
-        var b = OneOf<NumberReturning, NumberArrayReturning>.FromT0(new NumberReturning(new NumberScalar(100)));
+        OneOf<NumberReturning, NumberArrayReturning> a = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT1(new NumberArrayReturning(NumF("items", "total")));
+        OneOf<NumberReturning, NumberArrayReturning> b = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT0(new NumberReturning(new NumberScalar(100)));
 
-        var divide = new EachDivide(new[] { a, b });
+        EachDivide divide = new EachDivide([a, b]);
 
         Assert.NotNull(divide.Values);
     }
@@ -384,33 +508,37 @@ public sealed class PureQLTests
     // ── per-row date math ─────────────────────────────────────────────────────
 
     [Fact]
-    public void EachDateAddDays_ProducesDateArrayReturning()
+    public void EachDateAddDaysProducesDateArrayReturning()
     {
-        var left = OneOf<DateReturning, DateArrayReturning>.FromT1(
-            new DateArrayReturning(DateF("orders", "order_date"))
-        );
-        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
-            new NumberReturning(new NumberScalar(30))
-        );
+        OneOf<DateReturning, DateArrayReturning> left = OneOf<
+            DateReturning,
+            DateArrayReturning
+        >.FromT1(new DateArrayReturning(DateF("orders", "order_date")));
+        OneOf<NumberReturning, NumberArrayReturning> right = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT0(new NumberReturning(new NumberScalar(30)));
 
-        var addDays = new EachDateAddDays(left, right);
-        var result = new DateArrayReturning(addDays);
+        EachDateAddDays addDays = new EachDateAddDays(left, right);
+        DateArrayReturning result = new DateArrayReturning(addDays);
 
         Assert.True(result.IsT3);
     }
 
     [Fact]
-    public void EachDateDiffDays_ProducesNumericArrayReturning()
+    public void EachDateDiffDaysProducesNumericArrayReturning()
     {
-        var left = OneOf<DateReturning, DateArrayReturning>.FromT1(
-            new DateArrayReturning(DateF("orders", "delivered_at"))
-        );
-        var right = OneOf<DateReturning, DateArrayReturning>.FromT1(
-            new DateArrayReturning(DateF("orders", "order_date"))
-        );
+        OneOf<DateReturning, DateArrayReturning> left = OneOf<
+            DateReturning,
+            DateArrayReturning
+        >.FromT1(new DateArrayReturning(DateF("orders", "delivered_at")));
+        OneOf<DateReturning, DateArrayReturning> right = OneOf<
+            DateReturning,
+            DateArrayReturning
+        >.FromT1(new DateArrayReturning(DateF("orders", "order_date")));
 
-        var diff = new EachDateDiffDays(left, right);
-        var result = new NumberArrayReturning(diff);
+        EachDateDiffDays diff = new EachDateDiffDays(left, right);
+        NumberArrayReturning result = new NumberArrayReturning(diff);
 
         Assert.True(result.IsT4);
     }
@@ -418,33 +546,37 @@ public sealed class PureQLTests
     // ── per-row datetime math ─────────────────────────────────────────────────
 
     [Fact]
-    public void EachDateTimeAddSeconds_ProducesDateTimeArrayReturning()
+    public void EachDateTimeAddSecondsProducesDateTimeArrayReturning()
     {
-        var left = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT1(
-            new DateTimeArrayReturning(DtF("events", "started_at"))
-        );
-        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
-            new NumberReturning(new NumberScalar(3600))
-        );
+        OneOf<DateTimeReturning, DateTimeArrayReturning> left = OneOf<
+            DateTimeReturning,
+            DateTimeArrayReturning
+        >.FromT1(new DateTimeArrayReturning(DtF("events", "started_at")));
+        OneOf<NumberReturning, NumberArrayReturning> right = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT0(new NumberReturning(new NumberScalar(3600)));
 
-        var addSeconds = new EachDateTimeAddSeconds(left, right);
-        var result = new DateTimeArrayReturning(addSeconds);
+        EachDateTimeAddSeconds addSeconds = new EachDateTimeAddSeconds(left, right);
+        DateTimeArrayReturning result = new DateTimeArrayReturning(addSeconds);
 
         Assert.True(result.IsT3);
     }
 
     [Fact]
-    public void EachDateTimeDiffSeconds_ProducesNumericArrayReturning()
+    public void EachDateTimeDiffSecondsProducesNumericArrayReturning()
     {
-        var left = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT1(
-            new DateTimeArrayReturning(DtF("orders", "shipped_at"))
-        );
-        var right = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT1(
-            new DateTimeArrayReturning(DtF("orders", "ordered_at"))
-        );
+        OneOf<DateTimeReturning, DateTimeArrayReturning> left = OneOf<
+            DateTimeReturning,
+            DateTimeArrayReturning
+        >.FromT1(new DateTimeArrayReturning(DtF("orders", "shipped_at")));
+        OneOf<DateTimeReturning, DateTimeArrayReturning> right = OneOf<
+            DateTimeReturning,
+            DateTimeArrayReturning
+        >.FromT1(new DateTimeArrayReturning(DtF("orders", "ordered_at")));
 
-        var diff = new EachDateTimeDiffSeconds(left, right);
-        var result = new NumberArrayReturning(diff);
+        EachDateTimeDiffSeconds diff = new EachDateTimeDiffSeconds(left, right);
+        NumberArrayReturning result = new NumberArrayReturning(diff);
 
         Assert.True(result.IsT5);
     }
@@ -452,33 +584,37 @@ public sealed class PureQLTests
     // ── per-row time math ─────────────────────────────────────────────────────
 
     [Fact]
-    public void EachTimeAddSeconds_ProducesTimeArrayReturning()
+    public void EachTimeAddSecondsProducesTimeArrayReturning()
     {
-        var left = OneOf<TimeReturning, TimeArrayReturning>.FromT1(
-            new TimeArrayReturning(TimeF("shifts", "clock_in"))
-        );
-        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
-            new NumberReturning(new NumberScalar(28800))
-        );
+        OneOf<TimeReturning, TimeArrayReturning> left = OneOf<
+            TimeReturning,
+            TimeArrayReturning
+        >.FromT1(new TimeArrayReturning(TimeF("shifts", "clock_in")));
+        OneOf<NumberReturning, NumberArrayReturning> right = OneOf<
+            NumberReturning,
+            NumberArrayReturning
+        >.FromT0(new NumberReturning(new NumberScalar(28800)));
 
-        var addSeconds = new EachTimeAddSeconds(left, right);
-        var result = new TimeArrayReturning(addSeconds);
+        EachTimeAddSeconds addSeconds = new EachTimeAddSeconds(left, right);
+        TimeArrayReturning result = new TimeArrayReturning(addSeconds);
 
         Assert.True(result.IsT3);
     }
 
     [Fact]
-    public void EachTimeDiffSeconds_ProducesNumericArrayReturning()
+    public void EachTimeDiffSecondsProducesNumericArrayReturning()
     {
-        var left = OneOf<TimeReturning, TimeArrayReturning>.FromT1(
-            new TimeArrayReturning(TimeF("shifts", "clock_out"))
-        );
-        var right = OneOf<TimeReturning, TimeArrayReturning>.FromT1(
-            new TimeArrayReturning(TimeF("shifts", "clock_in"))
-        );
+        OneOf<TimeReturning, TimeArrayReturning> left = OneOf<
+            TimeReturning,
+            TimeArrayReturning
+        >.FromT1(new TimeArrayReturning(TimeF("shifts", "clock_out")));
+        OneOf<TimeReturning, TimeArrayReturning> right = OneOf<
+            TimeReturning,
+            TimeArrayReturning
+        >.FromT1(new TimeArrayReturning(TimeF("shifts", "clock_in")));
 
-        var diff = new EachTimeDiffSeconds(left, right);
-        var result = new NumberArrayReturning(diff);
+        EachTimeDiffSeconds diff = new EachTimeDiffSeconds(left, right);
+        NumberArrayReturning result = new NumberArrayReturning(diff);
 
         Assert.True(result.IsT6);
     }
@@ -486,11 +622,16 @@ public sealed class PureQLTests
     // ── Query.Where accepts booleanArrayReturning ─────────────────────────────
 
     [Fact]
-    public void Query_WhereAcceptsBooleanArrayReturning()
+    public void QueryWhereAcceptsBooleanArrayReturning()
     {
-        var from = new FromExpression("orders", "o");
-        var select = new[] { new SelectExpression(new ArrayReturning(new NumberArrayReturning(NumF("orders", "id")))) };
-        var whereExpr = new BooleanArrayReturning(
+        FromExpression from = new FromExpression("orders", "o");
+        SelectExpression[] select = new[]
+        {
+            new SelectExpression(
+                new ArrayReturning(new NumberArrayReturning(NumF("orders", "id")))
+            ),
+        };
+        BooleanArrayReturning whereExpr = new BooleanArrayReturning(
             new EachEquality(
                 new EachStringEquality(
                     new StringArrayReturning(StrF("orders", "status")),
@@ -501,23 +642,27 @@ public sealed class PureQLTests
             )
         );
 
-        var query = new Query(
+        Query query = new Query(
             from,
             select,
             OneOf<BooleanReturning, BooleanArrayReturning>.FromT1(whereExpr),
-            null, null, null, null, null
+            null,
+            null,
+            null,
+            null,
+            null
         );
 
-        Assert.NotNull(query.Where);
+        _ = Assert.NotNull(query.Where);
         Assert.True(query.Where!.Value.IsT1);
     }
 
     // ── Join.On accepts booleanArrayReturning ─────────────────────────────────
 
     [Fact]
-    public void Join_OnAcceptsEachEqualCondition()
+    public void JoinOnAcceptsEachEqualCondition()
     {
-        var on = new BooleanArrayReturning(
+        BooleanArrayReturning on = new BooleanArrayReturning(
             new EachEquality(
                 new EachNumberEquality(
                     new NumberArrayReturning(NumF("orders", "user_id")),
@@ -528,7 +673,7 @@ public sealed class PureQLTests
             )
         );
 
-        var join = new Join(JoinType.Inner, "users", on);
+        Join join = new Join(JoinType.Inner, "users", on);
 
         Assert.True(join.On.IsT1);
     }
@@ -536,34 +681,38 @@ public sealed class PureQLTests
     // ── aggregate in Returnings ───────────────────────────────────────────────
 
     [Fact]
-    public void NumberReturning_IncludesAggregate()
+    public void NumberReturningIncludesAggregate()
     {
-        var sumArg = new NumberArrayReturning(NumF("order_items", "price"));
-        var sum = new SumNumber(sumArg);
-        var aggregate = new NumberAggregate(sum);
-        var returning = new NumberReturning(aggregate);
+        NumberArrayReturning sumArg = new NumberArrayReturning(
+            NumF("order_items", "price")
+        );
+        SumNumber sum = new SumNumber(sumArg);
+        NumberAggregate aggregate = new NumberAggregate(sum);
+        NumberReturning returning = new NumberReturning(aggregate);
 
         Assert.True(returning.IsT3);
     }
 
     [Fact]
-    public void NumberReturning_IncludesCount()
+    public void NumberReturningIncludesCount()
     {
-        var countArg = new ArrayReturning(new NumberArrayReturning(NumF("orders", "id")));
-        var count = new Count(countArg);
-        var returning = new NumberReturning(count);
+        ArrayReturning countArg = new ArrayReturning(
+            new NumberArrayReturning(NumF("orders", "id"))
+        );
+        Count count = new Count(countArg);
+        NumberReturning returning = new NumberReturning(count);
 
         Assert.True(returning.IsT4);
     }
 
     [Fact]
-    public void NumberReturning_IncludesArithmetic()
+    public void NumberReturningIncludesArithmetic()
     {
-        var a = new NumberReturning(new NumberScalar(10));
-        var b = new NumberReturning(new NumberScalar(5));
-        var add = new Add(new[] { a, b });
-        var arithmetic = new Arithmetic(add);
-        var returning = new NumberReturning(arithmetic);
+        NumberReturning a = new NumberReturning(new NumberScalar(10));
+        NumberReturning b = new NumberReturning(new NumberScalar(5));
+        Add add = new Add([a, b]);
+        Arithmetic arithmetic = new Arithmetic(add);
+        NumberReturning returning = new NumberReturning(arithmetic);
 
         Assert.True(returning.IsT2);
     }
@@ -571,10 +720,10 @@ public sealed class PureQLTests
     // ── schema gap fixes ──────────────────────────────────────────────────────
 
     [Fact]
-    public void NullField_InFieldUnion_Constructs()
+    public void NullFieldInFieldUnionConstructs()
     {
-        var nullField = new NullField("orders", "deleted_at");
-        var field = new Field(nullField);
+        NullField nullField = new NullField("orders", "deleted_at");
+        Field field = new Field(nullField);
 
         Assert.Equal("orders", nullField.Entity);
         Assert.Equal("deleted_at", nullField.Field);
@@ -582,19 +731,19 @@ public sealed class PureQLTests
     }
 
     [Fact]
-    public void FromExpression_WithoutAlias_Constructs()
+    public void FromExpressionWithoutAliasConstructs()
     {
-        var from = new FromExpression("products");
+        FromExpression from = new FromExpression("products");
 
         Assert.Equal("products", from.Entity);
         Assert.Null(from.Alias);
     }
 
     [Fact]
-    public void Query_DistinctFlag_Constructs()
+    public void QueryDistinctFlagConstructs()
     {
-        var from = new FromExpression("orders");
-        var select = new[]
+        FromExpression from = new FromExpression("orders");
+        SelectExpression[] select = new[]
         {
             new SelectExpression(
                 new SingleValueReturning(new NumberReturning(new NumberScalar(1))),
@@ -602,7 +751,17 @@ public sealed class PureQLTests
             ),
         };
 
-        var query = new Query(from, select, null, null, null, null, null, null, distinct: true);
+        Query query = new Query(
+            from,
+            select,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            distinct: true
+        );
 
         Assert.True(query.Distinct);
     }

--- a/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
+++ b/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
@@ -1,7 +1,570 @@
+using OneOf;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.Arithmetics;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.EachArithmetics;
+using PureQL.CSharp.Model.EachBooleanOperations;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachDateArithmetics;
+using PureQL.CSharp.Model.EachDateTimeArithmetics;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.EachTimeArithmetics;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
 namespace PureQL.CSharp.Model.Tests;
 
-public sealed record PureQLTests
+public sealed class PureQLTests
 {
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static NumberField NumF(string entity, string field) => new(entity, field);
+    private static StringField StrF(string entity, string field) => new(entity, field);
+    private static DateField DateF(string entity, string field) => new(entity, field);
+    private static DateTimeField DtF(string entity, string field) => new(entity, field);
+    private static TimeField TimeF(string entity, string field) => new(entity, field);
+    private static UuidField UuidF(string entity, string field) => new(entity, field);
+    private static BooleanField BoolF(string entity, string field) => new(entity, field);
+
+    // ── basic query construction ──────────────────────────────────────────────
+
     [Fact]
-    public void FakeTest() { }
+    public void SimpleSelect_Constructs()
+    {
+        var from = new FromExpression("orders", "o");
+        var select = new[]
+        {
+            new SelectExpression(
+                new SingleValueReturning(
+                    new NumberReturning(new NumberScalar(1))
+                ),
+                "one"
+            ),
+        };
+
+        var query = new Query(from, select);
+
+        Assert.Equal("orders", query.From.Entity);
+        Assert.Single(query.SelectExpressions);
+    }
+
+    [Fact]
+    public void Query_WithPagination_Constructs()
+    {
+        var from = new FromExpression("users", "u");
+        var select = new[] { new SelectExpression(new ArrayReturning(new NumberArrayReturning(NumF("users", "id")))) };
+        var pagination = new Pagination(0, 10);
+
+        var query = new Query(from, select, null, null, null, null, null, pagination);
+
+        Assert.NotNull(query.Pagination);
+        Assert.Equal(0, query.Pagination!.Skip);
+        Assert.Equal(10, query.Pagination!.Take);
+    }
+
+    // ── OrderBy with direction ────────────────────────────────────────────────
+
+    [Fact]
+    public void OrderByItem_DefaultsToAsc()
+    {
+        var item = new OrderByItem(new Field(NumF("orders", "amount")));
+
+        Assert.Equal(SortDirection.Asc, item.Direction);
+    }
+
+    [Fact]
+    public void OrderByItem_ExplicitDesc()
+    {
+        var item = new OrderByItem(new Field(NumF("orders", "amount")), SortDirection.Desc);
+
+        Assert.Equal(SortDirection.Desc, item.Direction);
+    }
+
+    [Fact]
+    public void Query_WithOrderByItem_Constructs()
+    {
+        var from = new FromExpression("orders", "o");
+        var select = new[] { new SelectExpression(new ArrayReturning(new NumberArrayReturning(NumF("orders", "amount")))) };
+        var orderBy = new[]
+        {
+            new OrderByItem(new Field(NumF("orders", "amount")), SortDirection.Desc),
+        };
+
+        var query = new Query(from, select, null, null, null, null, orderBy, null);
+
+        Assert.Single(query.OrderBy!);
+        Assert.Equal(SortDirection.Desc, query.OrderBy!.First().Direction);
+    }
+
+    // ── each* equality ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EachNumberEquality_WithScalarRight_Constructs()
+    {
+        var left = new NumberArrayReturning(NumF("orders", "status_code"));
+        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
+            new NumberReturning(new NumberScalar(200))
+        );
+
+        var equality = new EachNumberEquality(left, right);
+        var boolArray = new BooleanArrayReturning(new EachEquality(equality));
+
+        Assert.True(boolArray.IsT4);
+    }
+
+    [Fact]
+    public void EachStringEquality_WithScalarRight_Constructs()
+    {
+        var left = new StringArrayReturning(StrF("users", "status"));
+        var right = OneOf<StringReturning, StringArrayReturning>.FromT0(
+            new StringReturning(new StringScalar("active"))
+        );
+
+        var equality = new EachStringEquality(left, right);
+        var boolArray = new BooleanArrayReturning(new EachEquality(equality));
+
+        Assert.True(boolArray.IsT4);
+    }
+
+    [Fact]
+    public void EachUuidEquality_FieldToField_Constructs()
+    {
+        var left = new UuidArrayReturning(UuidF("users", "id"));
+        var right = OneOf<UuidReturning, UuidArrayReturning>.FromT1(
+            new UuidArrayReturning(UuidF("orders", "user_id"))
+        );
+
+        var equality = new EachUuidEquality(left, right);
+
+        Assert.NotNull(equality);
+    }
+
+    [Fact]
+    public void EachDateEquality_Constructs()
+    {
+        var left = new DateArrayReturning(DateF("orders", "order_date"));
+        var right = OneOf<DateReturning, DateArrayReturning>.FromT0(
+            new DateReturning(new DateScalar(new DateOnly(2024, 1, 1)))
+        );
+
+        var equality = new EachDateEquality(left, right);
+
+        Assert.NotNull(equality);
+    }
+
+    [Fact]
+    public void EachBooleanEquality_Constructs()
+    {
+        var left = new BooleanArrayReturning(BoolF("users", "is_active"));
+        var right = OneOf<BooleanReturning, BooleanArrayReturning>.FromT0(
+            new BooleanReturning(new BooleanScalar(true))
+        );
+
+        var equality = new EachBooleanEquality(left, right);
+
+        Assert.NotNull(equality);
+    }
+
+    [Fact]
+    public void EachTimeEquality_Constructs()
+    {
+        var left = new TimeArrayReturning(TimeF("shifts", "start_time"));
+        var right = OneOf<TimeReturning, TimeArrayReturning>.FromT0(
+            new TimeReturning(new TimeScalar(new TimeOnly(8, 0, 0)))
+        );
+
+        var equality = new EachTimeEquality(left, right);
+
+        Assert.NotNull(equality);
+    }
+
+    [Fact]
+    public void EachDateTimeEquality_Constructs()
+    {
+        var left = new DateTimeArrayReturning(DtF("events", "starts_at"));
+        var right = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT0(
+            new DateTimeReturning(new DateTimeScalar(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)))
+        );
+
+        var equality = new EachDateTimeEquality(left, right);
+
+        Assert.NotNull(equality);
+    }
+
+    // ── each* comparisons ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void EachNumberComparison_GreaterThan_Constructs()
+    {
+        var left = new NumberArrayReturning(NumF("order_items", "unit_price"));
+        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
+            new NumberReturning(new NumberScalar(100))
+        );
+
+        var comparison = new EachNumberComparison(EachComparisonOperator.EachGreaterThan, left, right);
+        var boolArray = new BooleanArrayReturning(new EachComparison(comparison));
+
+        Assert.True(boolArray.IsT3);
+    }
+
+    [Fact]
+    public void EachDateComparison_FieldToField_Constructs()
+    {
+        var left = new DateArrayReturning(DateF("orders", "shipped_at"));
+        var right = OneOf<DateReturning, DateArrayReturning>.FromT1(
+            new DateArrayReturning(DateF("orders", "expected_at"))
+        );
+
+        var comparison = new EachDateComparison(EachComparisonOperator.EachLessThan, left, right);
+
+        Assert.Equal(EachComparisonOperator.EachLessThan, comparison.Operator);
+    }
+
+    [Fact]
+    public void EachStringComparison_Constructs()
+    {
+        var left = new StringArrayReturning(StrF("products", "name"));
+        var right = OneOf<StringReturning, StringArrayReturning>.FromT0(
+            new StringReturning(new StringScalar("M"))
+        );
+
+        var comparison = new EachStringComparison(EachComparisonOperator.EachGreaterThanOrEqual, left, right);
+
+        Assert.NotNull(comparison);
+    }
+
+    [Fact]
+    public void EachTimeComparison_Constructs()
+    {
+        var left = new TimeArrayReturning(TimeF("shifts", "clock_out"));
+        var right = OneOf<TimeReturning, TimeArrayReturning>.FromT0(
+            new TimeReturning(new TimeScalar(new TimeOnly(17, 0, 0)))
+        );
+
+        var comparison = new EachTimeComparison(EachComparisonOperator.EachGreaterThan, left, right);
+
+        Assert.NotNull(comparison);
+    }
+
+    [Fact]
+    public void EachDateTimeComparison_Constructs()
+    {
+        var left = new DateTimeArrayReturning(DtF("orders", "shipped_at"));
+        var right = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT0(
+            new DateTimeReturning(new DateTimeScalar(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)))
+        );
+
+        var comparison = new EachDateTimeComparison(EachComparisonOperator.EachGreaterThan, left, right);
+
+        Assert.NotNull(comparison);
+    }
+
+    // ── each* boolean operations ──────────────────────────────────────────────
+
+    [Fact]
+    public void EachAndOperator_ComposesMultiplePredicates()
+    {
+        var pred1 = new BooleanArrayReturning(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(StrF("users", "status")),
+                    OneOf<StringReturning, StringArrayReturning>.FromT0(
+                        new StringReturning(new StringScalar("active"))
+                    )
+                )
+            )
+        );
+
+        var pred2 = new BooleanArrayReturning(
+            new EachComparison(
+                new EachNumberComparison(
+                    EachComparisonOperator.EachGreaterThan,
+                    new NumberArrayReturning(NumF("users", "score")),
+                    OneOf<NumberReturning, NumberArrayReturning>.FromT0(
+                        new NumberReturning(new NumberScalar(50))
+                    )
+                )
+            )
+        );
+
+        var andOp = new EachAndOperator(new[] { pred1, pred2 });
+        var result = new BooleanArrayReturning(andOp);
+
+        Assert.True(result.IsT5);
+    }
+
+    [Fact]
+    public void EachOrOperator_Constructs()
+    {
+        var pred1 = new BooleanArrayReturning(BoolF("users", "is_premium"));
+        var pred2 = new BooleanArrayReturning(BoolF("users", "is_admin"));
+
+        var orOp = new EachOrOperator(new[] { pred1, pred2 });
+        var result = new BooleanArrayReturning(orOp);
+
+        Assert.True(result.IsT6);
+    }
+
+    [Fact]
+    public void EachNotOperator_Constructs()
+    {
+        var inner = new BooleanArrayReturning(
+            new EachEquality(
+                new EachBooleanEquality(
+                    new BooleanArrayReturning(BoolF("users", "is_deleted")),
+                    OneOf<BooleanReturning, BooleanArrayReturning>.FromT0(
+                        new BooleanReturning(new BooleanScalar(true))
+                    )
+                )
+            )
+        );
+
+        var notOp = new EachNotOperator(inner);
+        var result = new BooleanArrayReturning(notOp);
+
+        Assert.True(result.IsT7);
+    }
+
+    // ── per-row arithmetic ────────────────────────────────────────────────────
+
+    [Fact]
+    public void EachMultiply_FieldByScalar_ProducesNumericArrayReturning()
+    {
+        var fieldArg = OneOf<NumberReturning, NumberArrayReturning>.FromT1(
+            new NumberArrayReturning(NumF("order_items", "unit_price"))
+        );
+        var scalarArg = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
+            new NumberReturning(new NumberScalar(1.05))
+        );
+
+        var multiply = new EachMultiply(new[] { fieldArg, scalarArg });
+        var result = new NumberArrayReturning(new EachArithmetic(multiply));
+
+        Assert.True(result.IsT3);
+    }
+
+    [Fact]
+    public void EachAdd_ThreeOperands_Constructs()
+    {
+        var a = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "base_price")));
+        var b = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "tax")));
+        var c = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "shipping")));
+
+        var add = new EachAdd(new[] { a, b, c });
+
+        Assert.Equal(3, add.Values.Count());
+    }
+
+    [Fact]
+    public void EachSubtract_Constructs()
+    {
+        var a = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "price")));
+        var b = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "discount")));
+
+        var subtract = new EachSubtract(new[] { a, b });
+        var result = new NumberArrayReturning(new EachArithmetic(subtract));
+
+        Assert.True(result.IsT3);
+    }
+
+    [Fact]
+    public void EachDivide_Constructs()
+    {
+        var a = OneOf<NumberReturning, NumberArrayReturning>.FromT1(new NumberArrayReturning(NumF("items", "total")));
+        var b = OneOf<NumberReturning, NumberArrayReturning>.FromT0(new NumberReturning(new NumberScalar(100)));
+
+        var divide = new EachDivide(new[] { a, b });
+
+        Assert.NotNull(divide.Values);
+    }
+
+    // ── per-row date math ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void EachDateAddDays_ProducesDateArrayReturning()
+    {
+        var left = OneOf<DateReturning, DateArrayReturning>.FromT1(
+            new DateArrayReturning(DateF("orders", "order_date"))
+        );
+        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
+            new NumberReturning(new NumberScalar(30))
+        );
+
+        var addDays = new EachDateAddDays(left, right);
+        var result = new DateArrayReturning(addDays);
+
+        Assert.True(result.IsT3);
+    }
+
+    [Fact]
+    public void EachDateDiffDays_ProducesNumericArrayReturning()
+    {
+        var left = OneOf<DateReturning, DateArrayReturning>.FromT1(
+            new DateArrayReturning(DateF("orders", "delivered_at"))
+        );
+        var right = OneOf<DateReturning, DateArrayReturning>.FromT1(
+            new DateArrayReturning(DateF("orders", "order_date"))
+        );
+
+        var diff = new EachDateDiffDays(left, right);
+        var result = new NumberArrayReturning(diff);
+
+        Assert.True(result.IsT4);
+    }
+
+    // ── per-row datetime math ─────────────────────────────────────────────────
+
+    [Fact]
+    public void EachDateTimeAddSeconds_ProducesDateTimeArrayReturning()
+    {
+        var left = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT1(
+            new DateTimeArrayReturning(DtF("events", "started_at"))
+        );
+        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
+            new NumberReturning(new NumberScalar(3600))
+        );
+
+        var addSeconds = new EachDateTimeAddSeconds(left, right);
+        var result = new DateTimeArrayReturning(addSeconds);
+
+        Assert.True(result.IsT3);
+    }
+
+    [Fact]
+    public void EachDateTimeDiffSeconds_ProducesNumericArrayReturning()
+    {
+        var left = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT1(
+            new DateTimeArrayReturning(DtF("orders", "shipped_at"))
+        );
+        var right = OneOf<DateTimeReturning, DateTimeArrayReturning>.FromT1(
+            new DateTimeArrayReturning(DtF("orders", "ordered_at"))
+        );
+
+        var diff = new EachDateTimeDiffSeconds(left, right);
+        var result = new NumberArrayReturning(diff);
+
+        Assert.True(result.IsT5);
+    }
+
+    // ── per-row time math ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void EachTimeAddSeconds_ProducesTimeArrayReturning()
+    {
+        var left = OneOf<TimeReturning, TimeArrayReturning>.FromT1(
+            new TimeArrayReturning(TimeF("shifts", "clock_in"))
+        );
+        var right = OneOf<NumberReturning, NumberArrayReturning>.FromT0(
+            new NumberReturning(new NumberScalar(28800))
+        );
+
+        var addSeconds = new EachTimeAddSeconds(left, right);
+        var result = new TimeArrayReturning(addSeconds);
+
+        Assert.True(result.IsT3);
+    }
+
+    [Fact]
+    public void EachTimeDiffSeconds_ProducesNumericArrayReturning()
+    {
+        var left = OneOf<TimeReturning, TimeArrayReturning>.FromT1(
+            new TimeArrayReturning(TimeF("shifts", "clock_out"))
+        );
+        var right = OneOf<TimeReturning, TimeArrayReturning>.FromT1(
+            new TimeArrayReturning(TimeF("shifts", "clock_in"))
+        );
+
+        var diff = new EachTimeDiffSeconds(left, right);
+        var result = new NumberArrayReturning(diff);
+
+        Assert.True(result.IsT6);
+    }
+
+    // ── Query.Where accepts booleanArrayReturning ─────────────────────────────
+
+    [Fact]
+    public void Query_WhereAcceptsBooleanArrayReturning()
+    {
+        var from = new FromExpression("orders", "o");
+        var select = new[] { new SelectExpression(new ArrayReturning(new NumberArrayReturning(NumF("orders", "id")))) };
+        var whereExpr = new BooleanArrayReturning(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(StrF("orders", "status")),
+                    OneOf<StringReturning, StringArrayReturning>.FromT0(
+                        new StringReturning(new StringScalar("pending"))
+                    )
+                )
+            )
+        );
+
+        var query = new Query(
+            from,
+            select,
+            OneOf<BooleanReturning, BooleanArrayReturning>.FromT1(whereExpr),
+            null, null, null, null, null
+        );
+
+        Assert.NotNull(query.Where);
+        Assert.True(query.Where!.Value.IsT1);
+    }
+
+    // ── Join.On accepts booleanArrayReturning ─────────────────────────────────
+
+    [Fact]
+    public void Join_OnAcceptsEachEqualCondition()
+    {
+        var on = new BooleanArrayReturning(
+            new EachEquality(
+                new EachNumberEquality(
+                    new NumberArrayReturning(NumF("orders", "user_id")),
+                    OneOf<NumberReturning, NumberArrayReturning>.FromT1(
+                        new NumberArrayReturning(NumF("users", "id"))
+                    )
+                )
+            )
+        );
+
+        var join = new Join(JoinType.Inner, "users", on);
+
+        Assert.True(join.On.IsT1);
+    }
+
+    // ── aggregate in Returnings ───────────────────────────────────────────────
+
+    [Fact]
+    public void NumberReturning_IncludesAggregate()
+    {
+        var sumArg = new NumberArrayReturning(NumF("order_items", "price"));
+        var sum = new SumNumber(sumArg);
+        var aggregate = new NumberAggregate(sum);
+        var returning = new NumberReturning(aggregate);
+
+        Assert.True(returning.IsT3);
+    }
+
+    [Fact]
+    public void NumberReturning_IncludesCount()
+    {
+        var countArg = new ArrayReturning(new NumberArrayReturning(NumF("orders", "id")));
+        var count = new Count(countArg);
+        var returning = new NumberReturning(count);
+
+        Assert.True(returning.IsT4);
+    }
+
+    [Fact]
+    public void NumberReturning_IncludesArithmetic()
+    {
+        var a = new NumberReturning(new NumberScalar(10));
+        var b = new NumberReturning(new NumberScalar(5));
+        var add = new Add(new[] { a, b });
+        var arithmetic = new Arithmetic(add);
+        var returning = new NumberReturning(arithmetic);
+
+        Assert.True(returning.IsT2);
+    }
 }

--- a/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
+++ b/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
@@ -61,13 +61,13 @@ public sealed class PureQLTests
     public void SimpleSelectConstructs()
     {
         FromExpression from = new FromExpression("orders", "o");
-        SelectExpression[] select = new[]
-        {
+        SelectExpression[] select =
+        [
             new SelectExpression(
                 new SingleValueReturning(new NumberReturning(new NumberScalar(1))),
                 "one"
             ),
-        };
+        ];
 
         Query query = new Query(from, select);
 
@@ -79,12 +79,12 @@ public sealed class PureQLTests
     public void QueryWithPaginationConstructs()
     {
         FromExpression from = new FromExpression("users", "u");
-        SelectExpression[] select = new[]
-        {
+        SelectExpression[] select =
+        [
             new SelectExpression(
                 new ArrayReturning(new NumberArrayReturning(NumF("users", "id")))
             ),
-        };
+        ];
         Pagination pagination = new Pagination(0, 10);
 
         Query query = new Query(from, select, null, null, null, null, null, pagination);
@@ -119,16 +119,16 @@ public sealed class PureQLTests
     public void QueryWithOrderByItemConstructs()
     {
         FromExpression from = new FromExpression("orders", "o");
-        SelectExpression[] select = new[]
-        {
+        SelectExpression[] select =
+        [
             new SelectExpression(
                 new ArrayReturning(new NumberArrayReturning(NumF("orders", "amount")))
             ),
-        };
-        OrderByItem[] orderBy = new[]
-        {
+        ];
+        OrderByItem[] orderBy =
+        [
             new OrderByItem(new Field(NumF("orders", "amount")), SortDirection.Desc),
-        };
+        ];
 
         Query query = new Query(from, select, null, null, null, null, orderBy, null);
 
@@ -625,12 +625,12 @@ public sealed class PureQLTests
     public void QueryWhereAcceptsBooleanArrayReturning()
     {
         FromExpression from = new FromExpression("orders", "o");
-        SelectExpression[] select = new[]
-        {
+        SelectExpression[] select =
+        [
             new SelectExpression(
                 new ArrayReturning(new NumberArrayReturning(NumF("orders", "id")))
             ),
-        };
+        ];
         BooleanArrayReturning whereExpr = new BooleanArrayReturning(
             new EachEquality(
                 new EachStringEquality(
@@ -743,13 +743,13 @@ public sealed class PureQLTests
     public void QueryDistinctFlagConstructs()
     {
         FromExpression from = new FromExpression("orders");
-        SelectExpression[] select = new[]
-        {
+        SelectExpression[] select =
+        [
             new SelectExpression(
                 new SingleValueReturning(new NumberReturning(new NumberScalar(1))),
                 "one"
             ),
-        };
+        ];
 
         Query query = new Query(
             from,

--- a/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
+++ b/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
@@ -567,4 +567,43 @@ public sealed class PureQLTests
 
         Assert.True(returning.IsT2);
     }
+
+    // ── schema gap fixes ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void NullField_InFieldUnion_Constructs()
+    {
+        var nullField = new NullField("orders", "deleted_at");
+        var field = new Field(nullField);
+
+        Assert.Equal("orders", nullField.Entity);
+        Assert.Equal("deleted_at", nullField.Field);
+        Assert.True(field.IsT3);
+    }
+
+    [Fact]
+    public void FromExpression_WithoutAlias_Constructs()
+    {
+        var from = new FromExpression("products");
+
+        Assert.Equal("products", from.Entity);
+        Assert.Null(from.Alias);
+    }
+
+    [Fact]
+    public void Query_DistinctFlag_Constructs()
+    {
+        var from = new FromExpression("orders");
+        var select = new[]
+        {
+            new SelectExpression(
+                new SingleValueReturning(new NumberReturning(new NumberScalar(1))),
+                "one"
+            ),
+        };
+
+        var query = new Query(from, select, null, null, null, null, null, null, distinct: true);
+
+        Assert.True(query.Distinct);
+    }
 }


### PR DESCRIPTION
Closes #43

## Summary

- Fixes existing gaps in `*Returning` types (aggregates and arithmetic missing from v0.1.0-preview.0.1.0 alignment)
- Adds the full `each*` predicate family (`eachEqual`, `eachGreaterThan/LessThan/etc`, `eachAnd/Or/Not`) from spec `0.1.0-preview.0.2.0`
- Adds per-row arithmetic and date/time/datetime math operators (`eachAdd/Subtract/Multiply/Divide`, `eachDateAddDays`, `eachDateDiffDays`, `eachDatetimeAddSeconds`, `eachDatetimeDiffSeconds`, `eachTimeAddSeconds`, `eachTimeDiffSeconds`) from spec `0.1.0-preview.0.3.0`
- Adds `OrderByItem` with `SortDirection` enum from spec `0.1.0-preview.0.5.0`; `Query.OrderBy` changed from `IEnumerable<Field>?` to `IEnumerable<OrderByItem>?`
- Updates `Query.Where` and `Join.On` to accept both `BooleanReturning` and `BooleanArrayReturning`
- Adds 35 unit tests covering all new types and their compositions
- Adds README with full API reference and usage example
- Adds CHANGELOG

## Commit breakdown

Each version increment is a separate commit so the spec migration history is traceable.

## Test plan

- [ ] `dotnet build` succeeds across all target frameworks (net6.0 – net10.0)
- [ ] `dotnet test` — all 35 tests pass
- [ ] Each new `each*` type resolves to the correct `IsT{n}` discriminant in its parent union
- [ ] `Query.Where` accepts both `BooleanReturning` and `BooleanArrayReturning`
- [ ] `OrderByItem` defaults to `SortDirection.Asc`