### PR TITLE
Return scalar types from field Type properties per specification

### DIFF
--- a/src/PureQL.CSharp.Model/Fields/BooleanField.cs
+++ b/src/PureQL.CSharp.Model/Fields/BooleanField.cs
@@ -1,4 +1,3 @@
-using PureQL.CSharp.Model.ArrayTypes;
 using PureQL.CSharp.Model.Types;
 
 namespace PureQL.CSharp.Model.Fields;
@@ -15,5 +14,5 @@ public sealed record BooleanField : IField
 
     public string Field { get; }
 
-    public IType Type => new BooleanArrayType();
+    public IType Type => new BooleanType();
 }

--- a/src/PureQL.CSharp.Model/Fields/DateField.cs
+++ b/src/PureQL.CSharp.Model/Fields/DateField.cs
@@ -1,4 +1,3 @@
-using PureQL.CSharp.Model.ArrayTypes;
 using PureQL.CSharp.Model.Types;
 
 namespace PureQL.CSharp.Model.Fields;
@@ -15,5 +14,5 @@ public sealed record DateField : IField
 
     public string Field { get; }
 
-    public IType Type => new DateArrayType();
+    public IType Type => new DateType();
 }

--- a/src/PureQL.CSharp.Model/Fields/DateTimeField.cs
+++ b/src/PureQL.CSharp.Model/Fields/DateTimeField.cs
@@ -1,4 +1,3 @@
-using PureQL.CSharp.Model.ArrayTypes;
 using PureQL.CSharp.Model.Types;
 
 namespace PureQL.CSharp.Model.Fields;
@@ -15,5 +14,5 @@ public sealed record DateTimeField : IField
 
     public string Field { get; }
 
-    public IType Type => new DateTimeArrayType();
+    public IType Type => new DateTimeType();
 }

--- a/src/PureQL.CSharp.Model/Fields/NullField.cs
+++ b/src/PureQL.CSharp.Model/Fields/NullField.cs
@@ -1,4 +1,3 @@
-using PureQL.CSharp.Model.ArrayTypes;
 using PureQL.CSharp.Model.Types;
 
 namespace PureQL.CSharp.Model.Fields;
@@ -15,5 +14,5 @@ public sealed record NullField : IField
 
     public string Field { get; }
 
-    public IType Type => new NullArrayType();
+    public IType Type => new NullType();
 }

--- a/src/PureQL.CSharp.Model/Fields/NumberField.cs
+++ b/src/PureQL.CSharp.Model/Fields/NumberField.cs
@@ -1,4 +1,3 @@
-using PureQL.CSharp.Model.ArrayTypes;
 using PureQL.CSharp.Model.Types;
 
 namespace PureQL.CSharp.Model.Fields;
@@ -15,5 +14,5 @@ public sealed record NumberField : IField
 
     public string Field { get; }
 
-    public IType Type => new NumberArrayType();
+    public IType Type => new NumberType();
 }

--- a/src/PureQL.CSharp.Model/Fields/StringField.cs
+++ b/src/PureQL.CSharp.Model/Fields/StringField.cs
@@ -1,4 +1,3 @@
-using PureQL.CSharp.Model.ArrayTypes;
 using PureQL.CSharp.Model.Types;
 
 namespace PureQL.CSharp.Model.Fields;
@@ -15,5 +14,5 @@ public sealed record StringField : IField
 
     public string Field { get; }
 
-    public IType Type => new StringArrayType();
+    public IType Type => new StringType();
 }

--- a/src/PureQL.CSharp.Model/Fields/TimeField.cs
+++ b/src/PureQL.CSharp.Model/Fields/TimeField.cs
@@ -1,4 +1,3 @@
-using PureQL.CSharp.Model.ArrayTypes;
 using PureQL.CSharp.Model.Types;
 
 namespace PureQL.CSharp.Model.Fields;
@@ -15,5 +14,5 @@ public sealed record TimeField : IField
 
     public string Field { get; }
 
-    public IType Type => new TimeArrayType();
+    public IType Type => new TimeType();
 }

--- a/src/PureQL.CSharp.Model/Fields/UuidField.cs
+++ b/src/PureQL.CSharp.Model/Fields/UuidField.cs
@@ -1,4 +1,3 @@
-using PureQL.CSharp.Model.ArrayTypes;
 using PureQL.CSharp.Model.Types;
 
 namespace PureQL.CSharp.Model.Fields;
@@ -15,5 +14,5 @@ public sealed record UuidField : IField
 
     public string Field { get; }
 
-    public IType Type => new UuidArrayType();
+    public IType Type => new UuidType();
 }

--- a/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
+++ b/src/Tests/PureQL.CSharp.Model.Tests/PureQLTests.cs
@@ -765,4 +765,23 @@ public sealed class PureQLTests
 
         Assert.True(query.Distinct);
     }
+
+    // ── field types match the specification ───────────────────────────────────
+
+    [Theory]
+    [InlineData(typeof(NumberField), "number")]
+    [InlineData(typeof(StringField), "string")]
+    [InlineData(typeof(BooleanField), "boolean")]
+    [InlineData(typeof(NullField), "null")]
+    [InlineData(typeof(DateField), "date")]
+    [InlineData(typeof(TimeField), "time")]
+    [InlineData(typeof(DateTimeField), "datetime")]
+    [InlineData(typeof(UuidField), "uuid")]
+    public void FieldTypeNameMatchesSpecification(Type fieldType, string expectedName)
+    {
+        IField field = (IField)
+            Activator.CreateInstance(fieldType, "orders", "amount")!;
+
+        Assert.Equal(expectedName, field.Type.Name);
+    }
 }


### PR DESCRIPTION
## What
Changes every `IField` implementation to return the scalar type required by the [PureQL specification](https://github.com/kudima03/PureQL-Specification) instead of the array type:

| Field | Before | After |
|---|---|---|
| `NumberField` | `numberArray` | `number` |
| `StringField` | `stringArray` | `string` |
| `BooleanField` | `booleanArray` | `boolean` |
| `NullField` | `nullArray` | `null` |
| `DateField` | `dateArray` | `date` |
| `TimeField` | `timeArray` | `time` |
| `DateTimeField` | `datetimeArray` | `datetime` |
| `UuidField` | `uuidArray` | `uuid` |

The spec defines `fields/*.type` as a scalar type (e.g. `numberField.type` → `types/numberType`, `"name": { "const": "number" }`), and every sample in the spec repo uses scalar names for fields. The array names made `PureQL.CSharp.Model.Serialization` reject spec-valid JSON and emit spec-invalid JSON.

## Notes
- The `Type` property signature (`IType`) is unchanged, so package validation passes — this is not a binary breaking change. It is a behavioral change: consumers that cast `field.Type` to an `ArrayTypes` record (notably `PureQL.CSharp.Model.Serialization`'s `*FieldJsonModel`s) need a follow-up update.
- Added a `FieldTypeNameMatchesSpecification` theory pinning all 8 field type names to the spec constants.

## Testing
`dotnet build -warnaserror`, `dotnet format --verify-no-changes`, and `dotnet test` (46/46) all pass.

Fixes #57